### PR TITLE
Moved acquire token error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "2.2.21",
+  "version": "2.2.22",
   "description": "Frontend Typescript components for the Amplify team",
   "files": [
     "dist/*"

--- a/src/providers/AuthProvider/AuthProviderInner.tsx
+++ b/src/providers/AuthProvider/AuthProviderInner.tsx
@@ -55,6 +55,9 @@ const AuthProviderInner: FC<AuthProviderInnerProps> = ({
 
   useEffect(() => {
     if (error instanceof InteractionRequiredAuthError) {
+      console.error('Auth error!');
+      console.error(error);
+      console.log('Trying to log the user in with a redirect...');
       login(InteractionType.Redirect, GRAPH_REQUESTS.LOGIN);
     }
   }, [error, login]);
@@ -114,16 +117,9 @@ const AuthProviderInner: FC<AuthProviderInnerProps> = ({
           }
         })
         .catch((error: AuthError) => {
-          if (
-            error.errorCode === 'consent_required' ||
-            error.errorCode === 'interaction_required' ||
-            error.errorCode === 'login_required' ||
-            error.errorCode === 'no_tokens_found'
-          ) {
-            instance.loginRedirect(GRAPH_REQUESTS.LOGIN);
-          } else {
-            setAuthState('unauthorized');
-          }
+          console.log('Token error when trying to get roles!');
+          console.error(error);
+          setAuthState('unauthorized');
         });
     }
   }, [

--- a/src/utils/auth_environment.ts
+++ b/src/utils/auth_environment.ts
@@ -122,26 +122,10 @@ const acquireToken = async (
   instance: IPublicClientApplication,
   request = GRAPH_REQUESTS.LOGIN
 ) => {
-  return (
-    instance
-      .acquireTokenSilent({
-        ...request,
-        redirectUri: `${window.location.origin}/auth.html`,
-      })
-      .then((token) => {
-        if (!token?.accessToken) {
-          console.log(`Token acquire is empty: ${JSON.stringify(token)}`);
-          msalApp.acquireTokenRedirect(request);
-          throw new Error('Redirecting');
-        }
-        return token;
-      })
-      //Acquire token silent failure, and send an interactive request
-      .catch((error) => {
-        console.log(`Token acquire error: ${JSON.stringify(error)}`);
-        return error;
-      })
-  );
+  return instance.acquireTokenSilent({
+    ...request,
+    redirectUri: `${window.location.origin}/auth.html`,
+  });
 };
 
 const isReaderOnly = (roles: string[] | undefined) => {


### PR DESCRIPTION
Acquire token error handling has now been moved up one level to the `AuthProviderInner` component. Also added more logging so we have more knowledge when a acquire token error happens.