### PR TITLE
Fix endless refresh loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Frontend Typescript components for the Amplify team",
   "files": [
     "dist/*"

--- a/src/providers/AuthProvider/AuthProviderInner.tsx
+++ b/src/providers/AuthProvider/AuthProviderInner.tsx
@@ -103,7 +103,6 @@ const AuthProviderInner: FC<AuthProviderInnerProps> = ({
       !photo &&
       !roles
     ) {
-      const hasRefreshed = getHasRefreshed();
       // Get photo
       acquireToken(instance, GRAPH_REQUESTS_PHOTO).then(
         async (tokenResponse) => {
@@ -139,20 +138,21 @@ const AuthProviderInner: FC<AuthProviderInnerProps> = ({
             if (accessToken.roles) {
               setRoles(accessToken.roles as string[]);
             }
-            if (hasRefreshed) {
-              setHasRefreshed({ value: false });
-            }
+            setHasRefreshed({ value: false });
             setAuthState('authorized');
           }
         })
         .catch((error: AuthError) => {
           console.log('Token error when trying to get roles!');
           console.error(error);
+          const hasRefreshed = getHasRefreshed();
           if (hasRefreshed) {
             setAuthState('unauthorized');
           } else {
             // Hasn't refreshed automatically yet, refreshing...
             console.log('Trying an automatic refresh...');
+            window.localStorage.clear();
+            console.log('Clearing local storage...');
             setHasRefreshed({ value: true });
             window.location.reload();
           }


### PR DESCRIPTION
Got an endless refresh loop when using the new automatic refresh release when running Tools locally, this commit should fix that