### PR TITLE
Make portalToken param in useNotifications string | undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "3.7.15",
+  "version": "3.7.16",
   "description": "Frontend Typescript components for the Amplify team",
   "files": [
     "dist/*"

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -5,7 +5,7 @@ import { HubConnection } from '@microsoft/signalr/dist/esm/HubConnection';
 
 export function useNotifications<
   T extends { SequenceNumber?: number | null; Read?: boolean | null }
->(topic: string, host: string, amplifyPortalToken: string) {
+>(topic: string, host: string, amplifyPortalToken?: string) {
   const connectionRef = useRef<HubConnection | undefined>(undefined);
   const [notifications, setNotifications] = useState<T[]>([]);
   const [
@@ -24,7 +24,7 @@ export function useNotifications<
 
   useEffect(() => {
     const setupConnection = async () => {
-      if (!amplifyPortalToken) return;
+      if (amplifyPortalToken === undefined) return;
 
       const connection = new SignalR.HubConnectionBuilder()
         .withUrl(`${host}/hubs/notifications`, {


### PR DESCRIPTION
Fixes issue with portalToken not always being defined when using the hook in an application