### PR TITLE
Removing 'host' parameter from useSignarlR-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
Removing the 'host' parameter since we always want to use the portal-url based on which environment we are in