### PR TITLE
🐛 Ensure 2-digit day and month

### DIFF
--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -73,7 +73,7 @@ test('formatDate works as expected with format = "YYYY-MM-DD"', () => {
   const day = fakeDate.getDate();
   const month = fakeDate.getMonth() + 1;
   const year = fakeDate.getFullYear();
-  expect(formattedDate).toBe(`${year}-${month}-${day}`);
+  expect(formattedDate).toBe(`${year}-${month < 10 ? '0' + month : month}-${day < 10 ? '0' + day : day}`);
 });
 
 test('formatDate works as expected with format = "DD.MM.YY"', () => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -34,16 +34,12 @@ const formatDate = (
         })}`;
       }
       if (options?.format === 'YYYY-MM-DD') {
-        return `${year}-${month}-${day}`;
+        return `${year}-${month.toString().padStart(2,'0')}-${day.toString().padStart(2,'0')}`;
       }
       if (options?.format === 'DD.MM.YY') {
-        return `${day < 10 ? '0' + day : day}.${
-          month < 10 ? '0' + month : month
-        }.${year.toString().slice(-2)}`;
+        return `${day.toString().padStart(2,'0')}.${month.toString().padStart(2,'0')}.${year.toString().slice(-2)}`;
       }
-      return `${day < 10 ? '0' + day : day}.${
-        month < 10 ? '0' + month : month
-      }.${year}`;
+      return `${day.toString().padStart(2,'0')}.${month.toString().padStart(2,'0')}.${year}`;
     }
   }
   return '';


### PR DESCRIPTION
When using <Input type='date' > date string format YYYY-MM-DD requires 2-digit day and month.