### PR TITLE
Fixing missing $ on some styled-component's props, also fixing width of CopyText wrapper

### DIFF
--- a/.github/workflows/pr_actions.yaml
+++ b/.github/workflows/pr_actions.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +79,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/config/config_files/client.yaml
+++ b/config/config_files/client.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/components/DataDisplay/DataCard.tsx
+++ b/src/components/DataDisplay/DataCard.tsx
@@ -13,11 +13,7 @@ import styled from 'styled-components';
 
 const { colors, elevation, spacings } = tokens;
 
-interface CardProps {
-  onClick?: MouseEventHandler;
-}
-
-const Card = styled(EDSCard)<CardProps>`
+const Card = styled(EDSCard)`
   box-shadow: ${elevation.raised};
   grid-gap: 0;
   padding: ${spacings.comfortable.medium};

--- a/src/components/DataDisplay/InfoElement.stories.tsx
+++ b/src/components/DataDisplay/InfoElement.stories.tsx
@@ -8,6 +8,8 @@ export default {
   argTypes: {
     title: { control: 'text' },
     content: { control: 'text' },
+    copyableContent: { control: 'boolean' },
+    capitalizedContent: { control: 'boolean' },
   },
   args: {
     title: 'Title',
@@ -21,4 +23,4 @@ export const Primary = Template.bind({});
 Primary.args = {};
 
 export const WithCopyTextTrue = Template.bind({});
-WithCopyTextTrue.args = { copyableContent: true, copyBackground: '#ffffff' };
+WithCopyTextTrue.args = { copyableContent: true, capitalizeContent: false };

--- a/src/components/DataDisplay/Workflow/WorkflowStatusBar.tsx
+++ b/src/components/DataDisplay/Workflow/WorkflowStatusBar.tsx
@@ -30,7 +30,6 @@ const Wrapper = styled.div`
 interface CircleProps {
   $color?: string;
   $backgroundColor?: string;
-  index: number;
 }
 
 const Circle = styled.div<CircleProps>`
@@ -123,7 +122,6 @@ const WorkflowStatusBar: FC<WorkflowStatusBarProps> = ({
               )}
               {activeIdx === idx && showAlert && <Alert data-testid="alert" />}
               <Circle
-                index={idx}
                 $color={item.color}
                 $backgroundColor={item.backgroundColor}
               />

--- a/src/components/Feedback/Progress/FileProgress.tsx
+++ b/src/components/Feedback/Progress/FileProgress.tsx
@@ -35,7 +35,6 @@ const StyledButton = styled(Button)`
 `;
 
 interface TopProgressProps {
-  $paused?: boolean;
   $error?: boolean;
 }
 

--- a/src/components/Feedback/Progress/FileProgress.tsx
+++ b/src/components/Feedback/Progress/FileProgress.tsx
@@ -35,8 +35,8 @@ const StyledButton = styled(Button)`
 `;
 
 interface TopProgressProps {
-  paused?: boolean;
-  error?: boolean;
+  $paused?: boolean;
+  $error?: boolean;
 }
 
 const TopProgress = styled(Progress.Linear)<TopProgressProps>`
@@ -44,7 +44,7 @@ const TopProgress = styled(Progress.Linear)<TopProgressProps>`
   top: 0;
   div {
     background-color: ${(props) =>
-      props.error ? colors.interactive.danger__resting.hsla : ''};
+      props.$error ? colors.interactive.danger__resting.hsla : ''};
   }
 `;
 
@@ -104,7 +104,7 @@ const FileProgress: FC<FileProgressProps> = ({
             : 'indeterminate'
         }
         value={error || !loading ? 100 : progress ? progress : undefined}
-        error={error}
+        $error={error}
       />
       <CardHeader>
         <Card.HeaderTitle>

--- a/src/components/Inputs/CopyText.tsx
+++ b/src/components/Inputs/CopyText.tsx
@@ -11,6 +11,7 @@ const { colors, spacings } = tokens;
 const Wrapper = styled.div`
   position: relative;
   pointer-events: auto;
+  width: fit-content;
   &:hover {
     cursor: pointer;
   }

--- a/src/components/Inputs/PageMenu.tsx
+++ b/src/components/Inputs/PageMenu.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
 `;
 
 interface PageMenuItemProps {
-  active: boolean;
+  $active: boolean;
 }
 
 const PageMenuItem = styled.button<PageMenuItemProps>`
@@ -30,7 +30,7 @@ const PageMenuItem = styled.button<PageMenuItemProps>`
   padding: ${spacings.comfortable.medium_small} ${spacings.comfortable.medium};
   text-align: left;
   background: ${(props) =>
-    props.active ? colors.interactive.primary__hover_alt.hex : 'none'};
+    props.$active ? colors.interactive.primary__hover_alt.hex : 'none'};
   transition: background 400ms;
   &:hover {
     background: ${colors.interactive.primary__hover_alt.hex};
@@ -55,7 +55,7 @@ const PageMenu: FC = () => {
       {items.map((item) => (
         <PageMenuItem
           key={`page-menu-item-${item.value}`}
-          active={selected === item.value}
+          $active={selected === item.value}
           onClick={() => handleOnClick(item.value)}
           disabled={selected === item.value}
         >

--- a/src/components/Navigation/SideBar/MenuItem.tsx
+++ b/src/components/Navigation/SideBar/MenuItem.tsx
@@ -17,7 +17,7 @@ const { colors, spacings } = tokens;
 interface ContainerProps {
   $active?: boolean;
   $open?: boolean;
-  disabled?: boolean;
+  $disabled?: boolean;
 }
 
 const Container = styled.a<ContainerProps>`
@@ -35,7 +35,7 @@ const Container = styled.a<ContainerProps>`
   min-height: 72px;
 
   ${(props) =>
-    props.disabled
+    props.$disabled
       ? `
     &:hover {
       cursor: not-allowed;
@@ -115,7 +115,7 @@ const MenuItem = forwardRef<HTMLAnchorElement, MenuItemProps>(
           $open
           ref={ref}
           data-testid="sidebar-menu-item"
-          disabled={disabled}
+          $disabled={disabled}
         >
           {icon && <ItemIcon data={icon} size={24} color={getIconColor()} />}
           <ItemText variant="cell_text" group="table" $active={isCurrentUrl}>
@@ -133,7 +133,7 @@ const MenuItem = forwardRef<HTMLAnchorElement, MenuItemProps>(
           $open={isOpen}
           ref={ref}
           data-testid="sidebar-menu-item"
-          disabled={disabled}
+          $disabled={disabled}
         >
           {icon && <ItemIcon data={icon} size={24} color={getIconColor()} />}
         </Container>

--- a/src/components/Navigation/SideBar/ToggleOpen.tsx
+++ b/src/components/Navigation/SideBar/ToggleOpen.tsx
@@ -8,18 +8,18 @@ import styled from 'styled-components';
 
 const { colors, spacings, shape } = tokens;
 interface ContainerProps {
-  open?: boolean;
+  $open?: boolean;
 }
 
 const ToggleContainer = styled.div<ContainerProps>`
-  display: ${(props) => (props.open ? 'grid' : 'flex')};
+  display: ${(props) => (props.$open ? 'grid' : 'flex')};
   grid-template-columns: repeat(10, 1fr);
   grid-gap: ${spacings.comfortable.medium};
   justify-content: center;
   margin-top: auto;
   margin-bottom: ${spacings.comfortable.medium};
   ${(props) =>
-    !props.open &&
+    !props.$open &&
     `
     > button {
       margin-left: -4px;
@@ -61,7 +61,7 @@ interface ToggleOpenProps {
 const ToggleOpen: React.FC<ToggleOpenProps> = ({ isOpen, toggle }) => {
   if (isOpen) {
     return (
-      <ToggleContainer open={isOpen}>
+      <ToggleContainer $open={isOpen}>
         <LargeButton onClick={toggle}>
           <Icon
             size={24}
@@ -76,7 +76,7 @@ const ToggleOpen: React.FC<ToggleOpenProps> = ({ isOpen, toggle }) => {
     );
   }
   return (
-    <ToggleContainer open={isOpen}>
+    <ToggleContainer $open={isOpen}>
       <Tooltip title="Expand" placement="right">
         <Button onClick={toggle} color="secondary" variant="ghost_icon">
           <Icon


### PR DESCRIPTION
- Fixing styled-component props where $ is missing
- Fixing width of CopyText's wrapper not following width of element
- Bumping github action node versions to 20.x