### PR TITLE
Change how OpenAPI.TOKEN is being set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/api/core/OpenAPI.ts
+++ b/src/api/core/OpenAPI.ts
@@ -2,13 +2,14 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ApiRequestOptions } from './ApiRequestOptions';
-import { environment } from 'src/utils';
+import { auth, environment } from 'src/utils';
 import { CancelablePromise } from 'src/api/core/CancelablePromise';
 import { request as __request } from 'src/api/core/request';
 import { getLocalStorage, updateLocalStorage } from 'src/hooks/useLocalStorage';
 import { JwtPayload } from 'jwt-decode';
 import jwtDecode from 'jwt-decode';
 
+const { getToken: getApplicationToken } = auth;
 const { getApiUrl, getEnvironmentName } = environment;
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
@@ -95,7 +96,7 @@ export const OpenAPI: OpenAPIConfig = {
   VERSION: '1.0',
   WITH_CREDENTIALS: false,
   CREDENTIALS: 'include',
-  TOKEN: undefined,
+  TOKEN: getApplicationToken,
   USERNAME: undefined,
   PASSWORD: undefined,
   HEADERS: undefined,

--- a/src/providers/AuthProvider/AuthProvider.tsx
+++ b/src/providers/AuthProvider/AuthProvider.tsx
@@ -11,14 +11,9 @@ import { AccountInfo } from '@azure/msal-browser';
 import { MsalProvider } from '@azure/msal-react';
 
 import AuthProviderInner from './AuthProviderInner';
-import { OpenAPIConfig } from 'src/api';
-import { auth, environment } from 'src/utils';
+import { auth } from 'src/utils';
 
-const { createMsalApp } = auth;
-
-const msalApp = createMsalApp(
-  environment.getClientId(import.meta.env.VITE_CLIENT_ID)
-);
+const { msalApp } = auth;
 
 export type AuthState = 'loading' | 'authorized' | 'unauthorized';
 
@@ -41,7 +36,6 @@ export const useAuth = () => {
 
 interface AuthProviderProps {
   children: ReactNode;
-  openApiConfig: OpenAPIConfig;
   loadingComponent?: ReactElement;
   unauthorizedComponent?: ReactElement;
   isMock?: undefined;
@@ -92,7 +86,6 @@ const AuthProvider: FC<AuthProviderProps | MockAuthProviderProps> = (props) => {
     >
       <MsalProvider instance={msalApp}>
         <AuthProviderInner
-          openApiConfig={props.openApiConfig}
           loadingComponent={props.loadingComponent}
           unauthorizedComponent={props.unauthorizedComponent}
           account={account}

--- a/src/providers/AuthProvider/AuthProviderInner.tsx
+++ b/src/providers/AuthProvider/AuthProviderInner.tsx
@@ -9,7 +9,6 @@ import { AccountInfo } from '@azure/msal-common';
 import { useMsal, useMsalAuthentication } from '@azure/msal-react';
 
 import { AuthState } from './AuthProvider';
-import { OpenAPI, OpenAPIConfig } from 'src/api';
 import FullPageSpinner from 'src/components/Feedback/FullPageSpinner';
 import Unauthorized from 'src/components/Feedback/Unauthorized';
 import { auth, environment } from 'src/utils';
@@ -32,7 +31,6 @@ const { getApiScope } = environment;
 
 export interface AuthProviderInnerProps {
   children: ReactNode;
-  openApiConfig: OpenAPIConfig;
   account: AccountInfo | undefined;
   setAccount: (val: AccountInfo | undefined) => void;
   photo: string | undefined;
@@ -47,7 +45,6 @@ export interface AuthProviderInnerProps {
 
 const AuthProviderInner: FC<AuthProviderInnerProps> = ({
   children,
-  openApiConfig,
   account,
   setAccount,
   photo,
@@ -91,23 +88,10 @@ const AuthProviderInner: FC<AuthProviderInnerProps> = ({
     const currentAccount = result?.account || instance.getActiveAccount();
 
     if (currentAccount && account === undefined) {
-      console.log('Setting getToken function in open api configs!');
-      // Setting the OpenAPI config that has been sent from the given app (src/api)
-      openApiConfig.TOKEN = getToken;
-      // Setting the amplify-components specific OpenAPI config
-      OpenAPI.TOKEN = getToken;
       // Set AuthProvider account
       setAccount(currentAccount);
     }
-  }, [
-    account,
-    acquireToken,
-    getToken,
-    instance,
-    openApiConfig,
-    result?.account,
-    setAccount,
-  ]);
+  }, [account, acquireToken, getToken, instance, result?.account, setAccount]);
 
   useEffect(() => {
     if (!account || photo || roles) return;


### PR DESCRIPTION
Changed from setting the OpenAPI.TOKEN variable in the AuthProvider to just setting it in each apps "App.tsx" file like this

```
import { utils } from '@equinor/amplify-components';

import { OpenAPI } from 'src/api';

const { auth: { getToken } } = utils;

OpenAPI.TOKEN = getToken;

```