### PR TITLE
💄 Change to ghost button for application drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/components/Navigation/TopBar/ApplicationDrawer/ApplicationDrawer.tsx
+++ b/src/components/Navigation/TopBar/ApplicationDrawer/ApplicationDrawer.tsx
@@ -91,7 +91,7 @@ const ApplicationDrawer: FC = () => {
   return (
     <>
       <TopBarButton
-        variant="ghost_icon"
+        variant="ghost"
         onClick={toggleMenu}
         ref={buttonRef}
         $isSelected={isOpen}


### PR DESCRIPTION
Change application drawer button to ghost to match the rest of topbar 