### PR TITLE
Make combox stylable

### DIFF
--- a/config/config_files/.eslintrc.js
+++ b/config/config_files/.eslintrc.js
@@ -33,7 +33,13 @@ module.exports = {
       'error',
       { props: 'never', children: 'never' },
     ],
-    "@typescript-eslint/no-unused-vars": ["error", { "destructuredArrayIgnorePattern": "^_" }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        varsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+      },
+    ],
   },
   overrides: [
     {

--- a/src/components/Inputs/ComboBox/ComboBox.styles.ts
+++ b/src/components/Inputs/ComboBox/ComboBox.styles.ts
@@ -7,13 +7,27 @@ import styled from 'styled-components';
 
 const { colors, spacings: EDSSpacings } = tokens;
 
-export const Container = styled.div`
+interface ContainerProps {
+  $lightBackground?: boolean;
+  $underlineHighlight?: boolean;
+}
+
+export const Container = styled.div<ContainerProps>`
   position: relative;
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
   box-shadow: inset 0 -1px 0 0 ${colors.text.static_icons__tertiary.rgba};
   padding: ${spacings.medium_small} ${spacings.medium};
+
+  ${({ $underlineHighlight }) =>
+    $underlineHighlight
+      ? `box-shadow: inset 0 -2px 0 0 ${colors.infographic.substitute__blue_overcast.hex}`
+      : ''};
+
+  ${({ $lightBackground }) =>
+    `background-color: ${$lightBackground ? 'white' : 'default'}`};
+
   &[aria-expanded='true'] {
     box-shadow: inset 0 -2px 0 0 ${colors.interactive.primary__resting.rgba};
   }
@@ -95,13 +109,16 @@ export const Section = styled.section`
 
 interface StyledChipProps {
   $tryingToRemove: boolean;
+  $lightBackground?: boolean;
 }
 
 export const StyledChip = styled(Chip)<StyledChipProps>`
-  background: ${({ $tryingToRemove }) =>
+  background: ${({ $tryingToRemove, $lightBackground }) =>
     $tryingToRemove
       ? colors.interactive.primary__hover_alt.rgba
-      : colors.ui.background__default.rgba};
+      : $lightBackground
+        ? colors.ui.background__light.rgba
+        : colors.ui.background__default.rgba};
 `;
 
 interface CustomMenuItemProps {

--- a/src/components/Inputs/ComboBox/ComboBox.styles.ts
+++ b/src/components/Inputs/ComboBox/ComboBox.styles.ts
@@ -17,16 +17,17 @@ export const Container = styled.div<ContainerProps>`
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  box-shadow: inset 0 -1px 0 0 ${colors.text.static_icons__tertiary.rgba};
   padding: ${spacings.medium_small} ${spacings.medium};
 
   ${({ $underlineHighlight }) =>
     $underlineHighlight
-      ? `box-shadow: inset 0 -2px 0 0 ${colors.infographic.substitute__blue_overcast.hex}`
-      : ''};
+      ? `box-shadow: inset 0 -2px 0 0 ${colors.infographic.substitute__blue_overcast.rgba}`
+      : `box-shadow: inset 0 -1px 0 0 ${colors.text.static_icons__tertiary.rgba}`};
 
   ${({ $lightBackground }) =>
-    `background-color: ${$lightBackground ? 'white' : 'default'}`};
+    $lightBackground
+      ? `background-color: ${colors.ui.background__default.rgba}`
+      : `background-color: ${colors.ui.background__light.rgba}`};
 
   &[aria-expanded='true'] {
     box-shadow: inset 0 -2px 0 0 ${colors.interactive.primary__resting.rgba};

--- a/src/components/Inputs/ComboBox/ComboBox.test.tsx
+++ b/src/components/Inputs/ComboBox/ComboBox.test.tsx
@@ -1,7 +1,12 @@
+import { tokens } from '@equinor/eds-tokens';
 import { faker } from '@faker-js/faker';
 
 import { ComboBox } from './ComboBox';
 import { render, screen, userEvent } from 'src/tests/test-utils';
+
+import { expect } from 'vitest';
+
+const { colors } = tokens;
 
 function fakeItem() {
   return {
@@ -728,6 +733,86 @@ test('Loading works as expected', async () => {
   }
 
   expect(screen.getByRole('progressbar')).toBeInTheDocument();
+});
+
+test('underlineHighlight works as expected', async () => {
+  const items = fakeItems();
+  const label = faker.animal.bear();
+  const handleOnSelect = vi.fn();
+
+  const { rerender } = render(
+    <ComboBox
+      label={label}
+      onSelect={handleOnSelect}
+      values={[]}
+      items={items}
+    />
+  );
+
+  expect(screen.getByTestId('combobox-container')).toHaveStyleRule(
+    'box-shadow',
+    `inset 0 -1px 0 0 ${colors.text.static_icons__tertiary.rgba}`
+  );
+
+  rerender(
+    <ComboBox
+      label={label}
+      onSelect={handleOnSelect}
+      values={[]}
+      items={items}
+      underlineHighlight={true}
+    />
+  );
+
+  expect(screen.getByTestId('combobox-container')).toHaveStyleRule(
+    'box-shadow',
+    `inset 0 -2px 0 0 ${colors.infographic.substitute__blue_overcast.rgba}`
+  );
+});
+
+test('lightBackground works as expected', async () => {
+  const items = fakeItems();
+  const label = faker.animal.bear();
+  const handleOnSelect = vi.fn();
+
+  const { rerender } = render(
+    <ComboBox
+      label={label}
+      onSelect={handleOnSelect}
+      items={items}
+      value={items[0]}
+    />
+  );
+
+  expect(screen.queryByTestId('combobox-container')).toHaveStyleRule(
+    'background-color',
+    `${colors.ui.background__light.rgba}`
+  );
+
+  expect(screen.queryByTestId('amplify-combobox-chip')).toHaveStyleRule(
+    'background',
+    `${colors.ui.background__default.rgba}`
+  );
+
+  rerender(
+    <ComboBox
+      label={label}
+      onSelect={handleOnSelect}
+      items={items}
+      value={items[0]}
+      lightBackground={true}
+    />
+  );
+
+  expect(screen.queryByTestId('combobox-container')).toHaveStyleRule(
+    'background-color',
+    `${colors.ui.background__default.rgba}`
+  );
+
+  expect(screen.queryByTestId('amplify-combobox-chip')).toHaveStyleRule(
+    'background',
+    `${colors.ui.background__light.rgba}`
+  );
 });
 
 test('Not able to remove item when disabled/loading', async () => {

--- a/src/components/Inputs/ComboBox/ComboBox.tsx
+++ b/src/components/Inputs/ComboBox/ComboBox.tsx
@@ -33,6 +33,7 @@ export type ComboBoxComponentProps<T extends ComboBoxOption<T>> = {
   sortValues?: boolean;
   disabled?: boolean;
   loading?: boolean;
+  className?: string;
 } & (ComboBoxProps<T> | GroupedComboboxProps<T>);
 
 export const ComboBox = <T extends ComboBoxOption<T>>(
@@ -223,7 +224,7 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
   };
 
   return (
-    <>
+    <div className={props.className ?? ''}>
       <Container ref={anchorRef} onClick={handleOnOpen} aria-expanded={open}>
         {props.label && (
           <Label label={props.label} htmlFor="amplify-combobox" />
@@ -306,6 +307,6 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
           )}
         </Menu>
       )}
-    </>
+    </div>
   );
 };

--- a/src/components/Inputs/ComboBox/ComboBox.tsx
+++ b/src/components/Inputs/ComboBox/ComboBox.tsx
@@ -227,6 +227,7 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
   return (
     <div>
       <Container
+        data-testid="combobox-container"
         ref={anchorRef}
         onClick={handleOnOpen}
         aria-expanded={open}
@@ -241,6 +242,7 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
             selectedValues.map((value) => (
               <StyledChip
                 key={value.value}
+                data-testid="amplify-combobox-chip"
                 className="amplify-combo-box-chip"
                 onDelete={() => {
                   if (!props.loading && !props.disabled) {

--- a/src/components/Inputs/ComboBox/ComboBox.tsx
+++ b/src/components/Inputs/ComboBox/ComboBox.tsx
@@ -33,7 +33,8 @@ export type ComboBoxComponentProps<T extends ComboBoxOption<T>> = {
   sortValues?: boolean;
   disabled?: boolean;
   loading?: boolean;
-  className?: string;
+  lightBackground?: boolean;
+  underlineHighlight?: boolean;
 } & (ComboBoxProps<T> | GroupedComboboxProps<T>);
 
 export const ComboBox = <T extends ComboBoxOption<T>>(
@@ -224,8 +225,14 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
   };
 
   return (
-    <div className={props.className ?? ''}>
-      <Container ref={anchorRef} onClick={handleOnOpen} aria-expanded={open}>
+    <div>
+      <Container
+        ref={anchorRef}
+        onClick={handleOnOpen}
+        aria-expanded={open}
+        $underlineHighlight={props.underlineHighlight}
+        $lightBackground={props.lightBackground}
+      >
         {props.label && (
           <Label label={props.label} htmlFor="amplify-combobox" />
         )}
@@ -241,6 +248,7 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
                   }
                 }}
                 $tryingToRemove={tryingToRemoveItem?.value === value.value}
+                $lightBackground={props.lightBackground}
               >
                 {value.label}
               </StyledChip>

--- a/src/components/Inputs/ComboBox/ComboBoxMenuItem.tsx
+++ b/src/components/Inputs/ComboBox/ComboBoxMenuItem.tsx
@@ -131,7 +131,7 @@ export const ComboBoxMenuItem = <T extends ComboBoxOption<T>>(
     }
   };
 
-  if (item.children && multiselect) {
+  if (item.children && item.children.length > 0 && multiselect) {
     return (
       <>
         <MenuItemParentSelect


### PR DESCRIPTION
[AB#448602](https://dev.azure.com/Equinor/DPP%20Upscaling%20of%20digital%20solutions/_workitems/edit/448602)
Also extended linting configuration to be able to name not used variables. Various use cases.

Currently in need to use with typescripts `infer`
```
type ContainsDot<TParam extends string> =
  TParam extends `${infer _Start}.${infer _End}` ? TParam : never;
```