### PR TITLE
Fix onChange type in ISettingsSections interface

### DIFF
--- a/src/components/Navigation/TopBar/Settings.tsx
+++ b/src/components/Navigation/TopBar/Settings.tsx
@@ -41,7 +41,7 @@ const SettingsItems = styled.div`
 export interface ISettingsSections {
   title: string;
   type: string;
-  onChange?: (val: string) => void;
+  onChange?: (val: unknown) => void;
   items: {
     label: string;
     name: string;


### PR DESCRIPTION
The `onChange` function should be able to be assigned other types other than string