### PR TITLE
Clean up types in ComboBox so it is easier to use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.2.6",
+  "version": "7.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@equinor/amplify-components",
-      "version": "7.2.6",
+      "version": "7.2.9",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-browser": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.2.7",
+  "version": "7.2.8",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.2.8",
+  "version": "7.2.9",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/components/Inputs/ComboBox/ComboBox.tsx
+++ b/src/components/Inputs/ComboBox/ComboBox.tsx
@@ -20,6 +20,7 @@ import {
 } from './ComboBox.styles';
 import {
   ComboBoxOption,
+  ComboBoxOptionRequired,
   ComboBoxProps,
   GroupedComboboxProps,
 } from './ComboBox.types';
@@ -28,7 +29,7 @@ import { GroupedComboBoxMenu } from './GroupedComboBoxMenu';
 
 const { colors } = tokens;
 
-export type ComboBoxComponentProps<T extends ComboBoxOption<T>> = {
+export type ComboBoxComponentProps<T extends ComboBoxOptionRequired> = {
   label?: string;
   placeholder?: string;
   sortValues?: boolean;
@@ -39,7 +40,7 @@ export type ComboBoxComponentProps<T extends ComboBoxOption<T>> = {
   clearable?: boolean;
 } & (ComboBoxProps<T> | GroupedComboboxProps<T>);
 
-export const ComboBox = <T extends ComboBoxOption<T>>(
+export const ComboBox = <T extends ComboBoxOptionRequired>(
   props: ComboBoxComponentProps<T>
 ) => {
   const {
@@ -84,7 +85,7 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
     } else {
       flattenedItems = props.items.flatMap((item) => [
         { ...item },
-        ...((item.children as T[]) || []),
+        ...(item.children! || []),
       ]);
     }
 
@@ -141,7 +142,7 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
     }
   };
 
-  const handleOnItemSelect = (item: T) => {
+  const handleOnItemSelect = (item: ComboBoxOption<T>) => {
     if ('value' in props) {
       props.onSelect(item);
     } else if (
@@ -154,7 +155,7 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
       );
     } else if (props.values.find((i) => i.value === item.value)) {
       // Remove parent with all children
-      const copiedItem = JSON.parse(JSON.stringify(item)) as T;
+      const copiedItem = structuredClone(item);
       const removingValues: string[] = [copiedItem.value];
       const childItems = copiedItem.children ?? [];
       while (childItems.length > 0) {
@@ -169,7 +170,7 @@ export const ComboBox = <T extends ComboBoxOption<T>>(
       props.onSelect([...props.values, item], item);
     } else {
       // Add parent with all children
-      const copiedItem = JSON.parse(JSON.stringify(item)) as T;
+      const copiedItem = structuredClone(item);
       const newValues = [copiedItem];
       const childItems = copiedItem.children ?? [];
       while (childItems.length > 0) {

--- a/src/components/Inputs/ComboBox/ComboBox.types.ts
+++ b/src/components/Inputs/ComboBox/ComboBox.types.ts
@@ -1,62 +1,67 @@
 import { KeyboardEvent, MutableRefObject } from 'react';
 
-type ComboBoxOptionWithoutChildren<T> = {
+export interface ComboBoxOptionRequired {
   value: string;
   label: string;
-} & T;
-
-export interface ComboBoxOption<T = { value: string; label: string }> {
-  value: string;
-  label: string;
-  children?: ComboBoxOptionWithoutChildren<T>[];
 }
 
-interface SingleComboBoxCommon<T extends ComboBoxOption<T>> {
-  value: T | undefined;
-  onSelect: (value: T | undefined) => void;
+export type ComboBoxOption<T extends ComboBoxOptionRequired> = T & {
+  children?: T[];
+};
+
+interface SingleComboBoxCommon<T extends ComboBoxOptionRequired> {
+  value: ComboBoxOption<T> | undefined;
+  onSelect: (value: ComboBoxOption<T> | undefined) => void;
 }
 
-export interface MultiComboBoxCommon<T extends ComboBoxOption<T>> {
-  values: T[];
-  onSelect: (values: T[], selectedValue?: T) => void;
+export interface MultiComboBoxCommon<T extends ComboBoxOptionRequired> {
+  values: ComboBoxOption<T>[];
+  onSelect: (
+    values: ComboBoxOption<T>[],
+    selectedValue?: ComboBoxOption<T>
+  ) => void;
   selectableParent?: boolean;
 }
 
-type AmplifyComboboxCommon<T extends ComboBoxOption<T>> =
+type AmplifyComboboxCommon<T extends ComboBoxOptionRequired> =
   | SingleComboBoxCommon<T>
   | MultiComboBoxCommon<T>;
 
-export type GroupedComboboxProps<T extends ComboBoxOption<T>> =
+export type GroupedComboboxProps<T extends ComboBoxOptionRequired> =
   AmplifyComboboxCommon<T> & {
-    groups: { title: string; items: T[] }[];
+    groups: { title: string; items: ComboBoxOption<T>[] }[];
   };
 
-export type ComboBoxProps<T extends ComboBoxOption<T>> =
+export type ComboBoxProps<T extends ComboBoxOptionRequired> =
   AmplifyComboboxCommon<T> & {
-    items: T[];
+    items: ComboBoxOption<T>[];
   };
 
-export interface ComboBoxMenuProps<T extends ComboBoxOption<T>> {
+export interface ComboBoxMenuProps<T extends ComboBoxOptionRequired> {
   search: string;
   itemRefs: MutableRefObject<(HTMLButtonElement | null)[]>;
   onItemKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
-  onItemSelect: (item: T) => void;
+  onItemSelect: (item: ComboBoxOption<T>) => void;
   selectableParent?: boolean;
 }
 
-interface ComboBoxMenuItemProps<T> {
-  item: T;
+interface ComboBoxMenuItemProps<T extends ComboBoxOptionRequired> {
+  item: ComboBoxOption<T>;
   index: number;
   childOffset: number;
   depth?: number;
 }
 
-export type ComboBoxSingleSelectMenuItemProps<T extends ComboBoxOption<T>> = {
+export type ComboBoxSingleSelectMenuItemProps<
+  T extends ComboBoxOptionRequired,
+> = {
   multiselect?: undefined;
 } & Omit<ComboBoxMenuProps<T>, 'search'> &
   ComboBoxMenuItemProps<T>;
-export type ComboBoxMultiSelectMenuItemProps<T extends ComboBoxOption<T>> = {
-  multiselect: true;
-  values: T[];
-} & Omit<ComboBoxMenuProps<T>, 'search'> &
-  ComboBoxMenuItemProps<T>;
+
+export type ComboBoxMultiSelectMenuItemProps<T extends ComboBoxOptionRequired> =
+  {
+    multiselect: true;
+    values: ComboBoxOption<T>[];
+  } & Omit<ComboBoxMenuProps<T>, 'search'> &
+    ComboBoxMenuItemProps<T>;

--- a/src/components/Inputs/ComboBox/ComboBox.utils.ts
+++ b/src/components/Inputs/ComboBox/ComboBox.utils.ts
@@ -1,7 +1,7 @@
-import { ComboBoxOption } from './ComboBox.types';
+import { ComboBoxOption, ComboBoxOptionRequired } from './ComboBox.types';
 
-export function getChildOffset<T extends ComboBoxOption<T>>(
-  allItems: T[],
+export function getChildOffset<T extends ComboBoxOptionRequired>(
+  allItems: ComboBoxOption<T>[],
   topLevelIndex: number
 ): number {
   const offset = allItems.length;

--- a/src/components/Inputs/ComboBox/ComboBoxMenu.tsx
+++ b/src/components/Inputs/ComboBox/ComboBoxMenu.tsx
@@ -3,13 +3,13 @@ import { useMemo } from 'react';
 import { NoItemsFoundText } from './ComboBox.styles';
 import {
   ComboBoxMenuProps,
-  ComboBoxOption,
+  ComboBoxOptionRequired,
   ComboBoxProps,
 } from './ComboBox.types';
 import { getChildOffset } from './ComboBox.utils';
 import { ComboBoxMenuItem } from './ComboBoxMenuItem';
 
-export const ComboBoxMenu = <T extends ComboBoxOption<T>>(
+export const ComboBoxMenu = <T extends ComboBoxOptionRequired>(
   props: ComboBoxProps<T> & ComboBoxMenuProps<T>
 ) => {
   const {

--- a/src/components/Inputs/ComboBox/ComboBoxMenuItem.tsx
+++ b/src/components/Inputs/ComboBox/ComboBoxMenuItem.tsx
@@ -17,14 +17,14 @@ import {
 } from './ComboBox.styles';
 import {
   ComboBoxMultiSelectMenuItemProps,
-  ComboBoxOption,
+  ComboBoxOptionRequired,
   ComboBoxSingleSelectMenuItemProps,
 } from './ComboBox.types';
 import { getChildOffset } from './ComboBox.utils';
 
 const { colors } = tokens;
 
-export const ComboBoxMenuItem = <T extends ComboBoxOption<T>>(
+export const ComboBoxMenuItem = <T extends ComboBoxOptionRequired>(
   props:
     | ComboBoxSingleSelectMenuItemProps<T>
     | ComboBoxMultiSelectMenuItemProps<T>

--- a/src/components/Inputs/ComboBox/GroupedComboBoxMenu.tsx
+++ b/src/components/Inputs/ComboBox/GroupedComboBoxMenu.tsx
@@ -5,12 +5,12 @@ import { Menu } from '@equinor/eds-core-react';
 import { NoItemsFoundText } from './ComboBox.styles';
 import {
   ComboBoxMenuProps,
-  ComboBoxOption,
+  ComboBoxOptionRequired,
   GroupedComboboxProps,
 } from './ComboBox.types';
 import { ComboBoxMenuItem } from './ComboBoxMenuItem';
 
-export const GroupedComboBoxMenu = <T extends ComboBoxOption<T>>(
+export const GroupedComboBoxMenu = <T extends ComboBoxOptionRequired>(
   props: GroupedComboboxProps<T> & ComboBoxMenuProps<T>
 ) => {
   const { onItemSelect, onItemKeyDown, itemRefs, groups, search } = props;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -90,7 +90,10 @@ export { default as TopBar } from './Navigation/TopBar';
 export { default as ResourceMenuItem } from './Navigation/TopBar/Resources/ResourceMenuItem';
 export type { ContentProps, TemplateType } from './Template/Template';
 export { default as Template } from './Template/Template';
-export type { ComboBoxOption } from './Inputs/ComboBox/ComboBox.types';
+export type {
+  ComboBoxOption,
+  ComboBoxOptionRequired,
+} from './Inputs/ComboBox/ComboBox.types';
 
 // EDS re-exports
 export type {


### PR DESCRIPTION
- Exporting new type `ComboBoxOptionRequired` which includes the required types for an item in the combo box

---

Creds to @arkadiy93 for showing me [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)