### PR TITLE
Avoid showing 'unauthorized' before refreshing to login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.5.4",
+  "version": "7.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@equinor/amplify-components",
-      "version": "7.5.4",
+      "version": "7.5.5",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-browser": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.5.4",
+  "version": "7.5.5",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/providers/AuthProvider/AuthProviderInner.tsx
+++ b/src/providers/AuthProvider/AuthProviderInner.tsx
@@ -59,7 +59,7 @@ const AuthProviderInner: FC<AuthProviderInnerProps> = ({
   loadingComponent,
   unauthorizedComponent,
 }) => {
-  const { instance, accounts } = useMsal();
+  const { instance, accounts, inProgress } = useMsal();
   const { login, result, error, acquireToken } = useMsalAuthentication(
     InteractionType.Silent,
     GRAPH_REQUESTS_LOGIN
@@ -120,7 +120,13 @@ const AuthProviderInner: FC<AuthProviderInnerProps> = ({
   ]);
 
   useEffect(() => {
-    if (!account || !isInitialized || hasFetchedRolesAndPhoto.current) return;
+    if (
+      !account ||
+      !isInitialized ||
+      hasFetchedRolesAndPhoto.current ||
+      inProgress !== 'none'
+    )
+      return;
     hasFetchedRolesAndPhoto.current = true;
 
     const getPhoto = async () => {
@@ -186,6 +192,7 @@ const AuthProviderInner: FC<AuthProviderInnerProps> = ({
     acquireToken,
     error,
     isInitialized,
+    inProgress,
     setAuthState,
     setPhoto,
     setRoles,


### PR DESCRIPTION
Needs to be tested before moving to prod (idea is to test in LQT after this has been published)

---
Tested locally with build-and-use against dasha and pwex now and seems to be working