### PR TITLE
:bug: :white_check_mark: used replace prop to check if url is an exac…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.6.3",
+  "version": "7.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@equinor/amplify-components",
-      "version": "7.6.3",
+      "version": "7.6.4",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-browser": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.6.3",
+  "version": "7.6.4",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/components/Navigation/SideBar/MenuItem.test.tsx
+++ b/src/components/Navigation/SideBar/MenuItem.test.tsx
@@ -70,6 +70,13 @@ describe('MenuItem', () => {
     expect(icon).toHaveAttribute('width', '24px');
   };
 
+  test('should navigate if replace is set to true and url is a partial match', () => {
+    const props = fakeProps();
+    render(<MenuItem {...props} replace />, {
+      wrapper: wrapper,
+    });
+  });
+
   describe('Expanded', () => {
     beforeEach(() => {
       window.localStorage.setItem(
@@ -627,17 +634,42 @@ describe('MenuItem', () => {
       });
 
       describe('Selected', () => {
-        test('Click should do nothing', async () => {
+        test('should not register click event if url is partially the same', async () => {
           const props = fakeProps();
-          render(<MenuItem {...props} currentUrl={props.link} />, {
-            wrapper: wrapper,
-          });
+          render(
+            <MenuItem
+              {...props}
+              currentUrl={`${props.link}/${faker.airline.aircraftType()}`}
+            />,
+            {
+              wrapper: wrapper,
+            }
+          );
           const item = screen.getByTestId('sidebar-menu-item');
 
           const user = userEvent.setup();
           await user.click(item);
 
           expect(props.onClick).not.toHaveBeenCalled();
+        });
+        test('should register click event if url is partially the same when replace is set to true', async () => {
+          const props = fakeProps();
+          render(
+            <MenuItem
+              {...props}
+              currentUrl={`${props.link}/${faker.airline.aircraftType()}`}
+              replace
+            />,
+            {
+              wrapper: wrapper,
+            }
+          );
+          const item = screen.getByTestId('sidebar-menu-item');
+
+          const user = userEvent.setup();
+          await user.click(item);
+
+          expect(props.onClick).toHaveBeenCalled();
         });
 
         test('Tab + Enter should do nothing', async () => {

--- a/src/components/Navigation/SideBar/MenuItem.tsx
+++ b/src/components/Navigation/SideBar/MenuItem.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import { forwardRef, HTMLAttributes, useMemo } from 'react';
 
 import { Icon } from '@equinor/eds-core-react';
@@ -23,10 +24,21 @@ export type MenuItemProps = {
 
 const MenuItem = forwardRef<HTMLAnchorElement, MenuItemProps>(
   (
-    { currentUrl, icon, name, link, onClick, disabled = false, replace },
+    {
+      currentUrl,
+      icon,
+      name,
+      link,
+      onClick,
+      disabled = false,
+      replace = false,
+    },
     ref
   ) => {
-    const isCurrentUrl = currentUrl?.includes(link) ?? false;
+    const isCurrentUrl =
+      (replace
+        ? typeof currentUrl === 'string' && currentUrl === link
+        : currentUrl?.includes(link)) ?? false;
     const { isOpen } = useSideBar();
 
     const canNavigate = useMemo(


### PR DESCRIPTION
…t match

This allows for distinguishing from for instance search pages where search params are part of the url do not require a navigation and breadcrumb pages where the url path is built gradually depending on choices made and we want an option to move back to start