### PR TITLE
:sparkles: option to add hash navigation when using table of contents…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.7.3",
+  "version": "7.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@equinor/amplify-components",
-      "version": "7.7.3",
+      "version": "7.7.4",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-browser": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-components",
-  "version": "7.7.3",
+  "version": "7.7.4",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/components/Navigation/TableOfContents/TableOfContents.test.tsx
+++ b/src/components/Navigation/TableOfContents/TableOfContents.test.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
 
 import { faker } from '@faker-js/faker';
 
@@ -55,10 +56,12 @@ describe('button variant', () => {
       </div>,
       {
         wrapper: (props: { children: ReactNode }) => (
-          <TableOfContentsProvider items={items}>
-            {' '}
-            {props.children}
-          </TableOfContentsProvider>
+          <MemoryRouter>
+            <TableOfContentsProvider items={items}>
+              {' '}
+              {props.children}
+            </TableOfContentsProvider>
+          </MemoryRouter>
         ),
       }
     );
@@ -97,9 +100,11 @@ describe('button variant', () => {
       </div>,
       {
         wrapper: (props: { children: ReactNode }) => (
-          <TableOfContentsProvider items={items}>
-            {props.children}
-          </TableOfContentsProvider>
+          <MemoryRouter>
+            <TableOfContentsProvider items={items}>
+              {props.children}
+            </TableOfContentsProvider>
+          </MemoryRouter>
         ),
       }
     );
@@ -130,10 +135,12 @@ describe('button variant', () => {
       </div>,
       {
         wrapper: (props: { children: ReactNode }) => (
-          <TableOfContentsProvider items={items}>
-            {' '}
-            {props.children}
-          </TableOfContentsProvider>
+          <MemoryRouter>
+            <TableOfContentsProvider items={items}>
+              {' '}
+              {props.children}
+            </TableOfContentsProvider>
+          </MemoryRouter>
         ),
       }
     );
@@ -181,10 +188,12 @@ describe('border variant', () => {
       </div>,
       {
         wrapper: (props: { children: ReactNode }) => (
-          <TableOfContentsProvider items={items}>
-            {' '}
-            {props.children}
-          </TableOfContentsProvider>
+          <MemoryRouter>
+            <TableOfContentsProvider items={items}>
+              {' '}
+              {props.children}
+            </TableOfContentsProvider>
+          </MemoryRouter>
         ),
       }
     );
@@ -223,9 +232,11 @@ describe('border variant', () => {
       </div>,
       {
         wrapper: (props: { children: ReactNode }) => (
-          <TableOfContentsProvider items={items}>
-            {props.children}
-          </TableOfContentsProvider>
+          <MemoryRouter>
+            <TableOfContentsProvider items={items}>
+              {props.children}
+            </TableOfContentsProvider>
+          </MemoryRouter>
         ),
       }
     );
@@ -256,10 +267,12 @@ describe('border variant', () => {
       </div>,
       {
         wrapper: (props: { children: ReactNode }) => (
-          <TableOfContentsProvider items={items}>
-            {' '}
-            {props.children}
-          </TableOfContentsProvider>
+          <MemoryRouter>
+            <TableOfContentsProvider items={items}>
+              {' '}
+              {props.children}
+            </TableOfContentsProvider>
+          </MemoryRouter>
         ),
       }
     );
@@ -305,10 +318,12 @@ describe('border variant', () => {
       </div>,
       {
         wrapper: (props: { children: ReactNode }) => (
-          <TableOfContentsProvider items={items}>
-            {' '}
-            {props.children}
-          </TableOfContentsProvider>
+          <MemoryRouter>
+            <TableOfContentsProvider items={items}>
+              {' '}
+              {props.children}
+            </TableOfContentsProvider>
+          </MemoryRouter>
         ),
       }
     );
@@ -345,9 +360,11 @@ describe('border variant', () => {
       </div>,
       {
         wrapper: (props: { children: ReactNode }) => (
-          <TableOfContentsProvider items={items}>
-            {props.children}
-          </TableOfContentsProvider>
+          <MemoryRouter>
+            <TableOfContentsProvider items={items}>
+              {props.children}
+            </TableOfContentsProvider>
+          </MemoryRouter>
         ),
       }
     );

--- a/src/providers/TableOfContentsProvider.test.tsx
+++ b/src/providers/TableOfContentsProvider.test.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { faker } from '@faker-js/faker';
 
@@ -36,9 +37,11 @@ test('SetItemRef works as expected', () => {
     </div>,
     {
       wrapper: (props: { children: ReactNode }) => (
-        <TableOfContentsProvider items={items}>
-          {props.children}
-        </TableOfContentsProvider>
+        <MemoryRouter>
+          <TableOfContentsProvider items={items}>
+            {props.children}
+          </TableOfContentsProvider>
+        </MemoryRouter>
       ),
     }
   );

--- a/src/providers/TableOfContentsProvider.tsx
+++ b/src/providers/TableOfContentsProvider.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { useNavigate } from 'react-router';
 
 import { TableOfContentsVariants } from 'src/components/Navigation/TableOfContents/TableOfContents.types';
 import { useOnScreenMultiple } from 'src/hooks/useOnScreen';
@@ -46,12 +47,15 @@ export function useTableOfContents() {
 export interface TableOfContentsProviderProps {
   items: TableOfContentsItemType[];
   children: ReactNode;
+  hashNavigation?: boolean;
 }
 
 const TableOfContentsProvider: FC<TableOfContentsProviderProps> = ({
   items,
   children,
+  hashNavigation,
 }) => {
+  const navigate = useNavigate();
   const [selected, setSelected] = useState<string | undefined>(items[0]?.value);
   const [elements, setElements] = useState<(Element | null)[]>([]);
 
@@ -106,6 +110,9 @@ const TableOfContentsProvider: FC<TableOfContentsProviderProps> = ({
             same += 1;
             if (same > 1) {
               setSelected(values[selectedIndex]);
+              if (hashNavigation) {
+                navigate(`#${values[selectedIndex]}`);
+              }
               isScrollingTo.current = -1;
               return;
             }
@@ -119,7 +126,7 @@ const TableOfContentsProvider: FC<TableOfContentsProviderProps> = ({
         requestAnimationFrame(checkScrollDone);
       }
     },
-    [elements, values]
+    [elements, hashNavigation, navigate, values]
   );
 
   // Handle change of selected when scrolling down the page
@@ -140,8 +147,11 @@ const TableOfContentsProvider: FC<TableOfContentsProviderProps> = ({
     }
     if (newSelectedIndex !== -1 && values.at(newSelectedIndex) !== undefined) {
       setSelected(values[newSelectedIndex]);
+      if (hashNavigation) {
+        navigate(`#${values[newSelectedIndex]}`);
+      }
     }
-  }, [values, visible]);
+  }, [hashNavigation, navigate, values, visible]);
   /* c8 ignore end */
 
   return (


### PR DESCRIPTION
… provider

When doing navigation, also set a hash of the id so that navigation can potentially be done via setting the id in the url instead of having to use the table of content controller or by scrolling