### PR TITLE
:hammer: reduced playwright expect timeout time

### DIFF
--- a/config/config_files/playwright.config.ts
+++ b/config/config_files/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 10000,
+    timeout: 5000,
   },
   /* Run e2e in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
Halved the timeout, IMHO, does not really make sense unless something is wrong with the test in which case it should be fixed instead