### PR TITLE
✨ Add amplify-backend as codeowners for server directory

### DIFF
--- a/config/config_files/CODEOWNERS
+++ b/config/config_files/CODEOWNERS
@@ -1,1 +1,2 @@
 /client/ @equinor/amplify-frontend
+/server/ @equinor/amplify-backend


### PR DESCRIPTION
If your application has a server directory, we wan't the amplify-backend team to be assigned to pullrequest made in there.