### PR TITLE
🚧 Accessibility improvement

### DIFF
--- a/src/components/Inputs/ComboBox/ComboBox.styles.ts
+++ b/src/components/Inputs/ComboBox/ComboBox.styles.ts
@@ -19,7 +19,7 @@ export const Container = styled.div<ContainerProps>`
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  padding: 6px 8px;
+  padding: 6px 64px 6px 8px;
 
   ${({ $underlineHighlight }) =>
     $underlineHighlight
@@ -113,21 +113,26 @@ export const Section = styled.section`
   }
 `;
 
-export const ClearButton = styled(Button)`
+export const InputAdornments = styled.div`
   position: absolute;
-  top: 50%;
-  transform: translate(0, -50%);
-  right: 26px;
+  right: 0;
+  display: flex;
+  padding-right: ${spacings.small};
+`;
+
+export const ClearButton = styled(Button)`
   width: 24px;
   height: 24px;
-  svg {
-    fill: ${EDSColors.text.static_icons__secondary.rgba};
-  }
   &:after {
     width: 24px;
     height: 24px;
     left: 0;
   }
+`;
+
+export const ToggleButton = styled(Button)`
+  width: 24px;
+  height: 24px;
 `;
 
 interface StyledChipProps {
@@ -149,6 +154,11 @@ interface CustomMenuItemProps {
 }
 
 export const MenuItemMultiselect = styled(Menu.Item)<CustomMenuItemProps>`
+  &:focus {
+    outline: none;
+    border: none;
+    background-color: ${EDSColors.ui.background__medium.rgba};
+  }
   > div {
     display: grid;
     /* This is tested but the code coverage doesn't recognize it */
@@ -160,6 +170,11 @@ export const MenuItemMultiselect = styled(Menu.Item)<CustomMenuItemProps>`
 `;
 
 export const MenuItemParentSelect = styled(Menu.Item)<CustomMenuItemProps>`
+  &:focus {
+    outline: none;
+    border: none;
+    background-color: ${EDSColors.ui.background__medium.rgba};
+  }
   > div {
     display: grid;
     /* This is tested but the code coverage doesn't recognize it */
@@ -178,12 +193,17 @@ export const MenuItemSpacer = styled.hr`
 `;
 
 export const PlaceholderText = styled(Typography)`
-  position: absolute;
-  color: ${EDSColors.text.static_icons__tertiary.rgba};
-  top: calc(50%);
-  transform: translate(0, -50%);
+  color: ${EDSColors.text.static_icons__default.rgba};
 `;
 
 export const NoItemsFoundText = styled(Typography)`
   margin-left: ${EDSSpacings.comfortable.medium};
+`;
+
+export const MenuItem = styled(Menu.Item)`
+  &:focus {
+    outline: none;
+    border: none;
+    background-color: ${EDSColors.ui.background__medium.rgba};
+  }
 `;

--- a/src/components/Inputs/ComboBox/ComboBox.types.ts
+++ b/src/components/Inputs/ComboBox/ComboBox.types.ts
@@ -42,6 +42,7 @@ export interface ComboBoxMenuProps<T extends ComboBoxOptionRequired> {
   itemRefs: MutableRefObject<(HTMLButtonElement | null)[]>;
   onItemKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
   onItemSelect: (item: ComboBoxOption<T>) => void;
+  onMouseEnter: () => void;
   selectableParent?: boolean;
 }
 

--- a/src/components/Inputs/ComboBox/ComboBoxMenu.tsx
+++ b/src/components/Inputs/ComboBox/ComboBoxMenu.tsx
@@ -18,6 +18,7 @@ export const ComboBoxMenu = <T extends ComboBoxOptionRequired>(
     onItemSelect,
     itemRefs,
     onItemKeyDown,
+    onMouseEnter,
     selectableParent,
   } = props;
 
@@ -40,6 +41,7 @@ export const ComboBoxMenu = <T extends ComboBoxOptionRequired>(
         multiselect
         item={item}
         itemRefs={itemRefs}
+        onMouseEnter={onMouseEnter}
         onItemKeyDown={onItemKeyDown}
         onItemSelect={onItemSelect}
         values={props.values}
@@ -55,6 +57,7 @@ export const ComboBoxMenu = <T extends ComboBoxOptionRequired>(
       index={index}
       item={item}
       itemRefs={itemRefs}
+      onMouseEnter={onMouseEnter}
       onItemKeyDown={onItemKeyDown}
       onItemSelect={onItemSelect}
       selectableParent={selectableParent}

--- a/src/components/Inputs/ComboBox/ComboBoxMenuItem.tsx
+++ b/src/components/Inputs/ComboBox/ComboBoxMenuItem.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, MouseEvent, useMemo, useRef, useState } from 'react';
 
-import { Icon, Menu } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react';
 import {
   arrow_drop_down,
   arrow_drop_up,
@@ -11,6 +11,7 @@ import {
 import { tokens } from '@equinor/eds-tokens';
 
 import {
+  MenuItem,
   MenuItemMultiselect,
   MenuItemParentSelect,
   MenuItemSpacer,
@@ -36,6 +37,7 @@ export const ComboBoxMenuItem = <T extends ComboBoxOptionRequired>(
     item,
     multiselect,
     itemRefs,
+    onMouseEnter,
     onItemKeyDown,
     onItemSelect,
     selectableParent = true,
@@ -128,8 +130,19 @@ export const ComboBoxMenuItem = <T extends ComboBoxOptionRequired>(
     ) {
       focusingChildIndex.current = 0;
       childRefs.current[focusingChildIndex.current + childOffset]?.focus();
+    } else if (
+      openParent &&
+      event.key === 'ArrowUp' &&
+      focusingChildIndex.current === -1
+    ) {
+      setOpenParent(false);
     }
   };
+
+  const handleMouseEnter = (event: MouseEvent<HTMLButtonElement>) => {
+    onMouseEnter();
+    event.currentTarget.focus();
+  }
 
   if (item.children && item.children.length > 0 && multiselect) {
     return (
@@ -173,6 +186,7 @@ export const ComboBoxMenuItem = <T extends ComboBoxOptionRequired>(
               values={props.values}
               onItemKeyDown={handleOnChildKeyDown}
               onItemSelect={onItemSelect}
+              onMouseEnter={onMouseEnter}
               selectableParent={selectableParent}
             />
           ))}
@@ -208,7 +222,7 @@ export const ComboBoxMenuItem = <T extends ComboBoxOptionRequired>(
   }
 
   return (
-    <Menu.Item
+    <MenuItem
       $depth={depth}
       ref={(element: HTMLButtonElement | null) => {
         itemRefs.current[index] = element;
@@ -216,8 +230,9 @@ export const ComboBoxMenuItem = <T extends ComboBoxOptionRequired>(
       index={index}
       onKeyDownCapture={onItemKeyDown}
       onClick={handleOnClick}
+      onMouseEnter={handleMouseEnter}
     >
       {item.label}
-    </Menu.Item>
+    </MenuItem>
   );
 };

--- a/src/components/Inputs/ComboBox/GroupedComboBoxMenu.tsx
+++ b/src/components/Inputs/ComboBox/GroupedComboBoxMenu.tsx
@@ -13,7 +13,7 @@ import { ComboBoxMenuItem } from './ComboBoxMenuItem';
 export const GroupedComboBoxMenu = <T extends ComboBoxOptionRequired>(
   props: GroupedComboboxProps<T> & ComboBoxMenuProps<T>
 ) => {
-  const { onItemSelect, onItemKeyDown, itemRefs, groups, search } = props;
+  const { onItemSelect, onItemKeyDown, itemRefs, onMouseEnter, groups, search } = props;
 
   const filteredGroups = useMemo(() => {
     if (search === '') return groups;
@@ -60,6 +60,7 @@ export const GroupedComboBoxMenu = <T extends ComboBoxOptionRequired>(
             itemRefs={itemRefs}
             onItemKeyDown={onItemKeyDown}
             onItemSelect={onItemSelect}
+            onMouseEnter={onMouseEnter}
             values={props.values}
           />
         ))}
@@ -82,6 +83,7 @@ export const GroupedComboBoxMenu = <T extends ComboBoxOptionRequired>(
           itemRefs={itemRefs}
           onItemKeyDown={onItemKeyDown}
           onItemSelect={onItemSelect}
+          onMouseEnter={onMouseEnter}
         />
       ))}
     </Menu.Section>


### PR DESCRIPTION
User story: [AB#485888](https://dev.azure.com/Equinor/4319082b-29ba-4111-a20b-c04f55c7e7c6/_workitems/edit/485888)

- Changed focus style on keyboard navigation
- Make focus go from last item in the list to the first when using arrow down (same behavior as EDS AutoComplete)
- Ability to keyboard navigate up and down between children and parents
- Change color of icon for open-button to primary resting
- Use the right clear-icon
- Option to display as text instead of chips (I think Per Christian changed his mind on this one, so this code could be removed)

Unsolved issue: When user tab-navigates through the menu items so that one item has focus, and also mouse hover over a different item, two items have focus style on the same time. There should only be one focused element at any time. When mouse hover a menu item, it should set element.focus().