### PR TITLE
feat: adds onSearchChange callback to ComboBox component

### DIFF
--- a/src/components/Inputs/ComboBox/ComboBox.test.tsx
+++ b/src/components/Inputs/ComboBox/ComboBox.test.tsx
@@ -1100,3 +1100,27 @@ test('Chevron button works as expected', async () => {
       expect(screen.queryByText(child.label)).toBeInTheDocument()
     );
 });
+
+test('onSearchCange to be called with value when typing in input field', async () => {
+  const label = faker.animal.bear();
+  const handler = vi.fn();
+  const items = fakeItems();
+  const id = faker.string.uuid();
+  const handleSeachChange = vi.fn();
+
+  render(
+    <ComboBox
+      id={id}
+      label={label}
+      onSelect={handler}
+      items={items}
+      value={items[0]}
+      onSearchChange={handleSeachChange}
+    />
+  );
+
+  const user = userEvent.setup();
+  const searchField = screen.getByRole('combobox');
+  await user.type(searchField, 'Test');
+  expect(handleSeachChange).toHaveBeenCalledWith('Test');
+});

--- a/src/components/Inputs/ComboBox/ComboBox.tsx
+++ b/src/components/Inputs/ComboBox/ComboBox.tsx
@@ -32,6 +32,7 @@ export type ComboBoxComponentProps<T extends ComboBoxOptionRequired> = {
   loading?: boolean;
   lightBackground?: boolean;
   underlineHighlight?: boolean;
+  onSearchChange?: (inputValue: string) => void;
   clearable?: boolean;
 } & (ComboBoxProps<T> | GroupedComboboxProps<T>);
 

--- a/src/hooks/useComboBox.ts
+++ b/src/hooks/useComboBox.ts
@@ -21,6 +21,7 @@ export type ComboBoxComponentProps<T extends ComboBoxOptionRequired> = {
   sortValues?: boolean;
   disabled?: boolean;
   loading?: boolean;
+  onSearchChange?: (inputValue: string) => void;
 } & (ComboBoxProps<T> | GroupedComboboxProps<T>);
 
 const useComboBox = <T extends ComboBoxOptionRequired>(
@@ -111,6 +112,7 @@ const useComboBox = <T extends ComboBoxOptionRequired>(
   const handleOnSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.value === ' ' || loading || disabled) return;
     setSearch(event.target.value);
+    props.onSearchChange?.(event.target.value);
     if (!open) {
       setOpen(true);
     }


### PR DESCRIPTION
Adds a new callback prop to the ComboBox component.
`onSearchChange` gets run everytime the value of the input field changes with the new string value of the field.

This is needed where users want to be able to add new items to the availble list if there are not matches by clicking some button or pressing enter. The callback allows the user to get the search value out of the component.