### PR TITLE
fix: removes conditional render and uses the open prop hide and show dropdown

### DIFF
--- a/src/components/Inputs/ComboBox/ComboBox.tsx
+++ b/src/components/Inputs/ComboBox/ComboBox.tsx
@@ -139,37 +139,36 @@ export const ComboBox = <T extends ComboBoxOptionRequired>(
           </ClearButton>
         )}
       </Container>
-      {open && (
-        <StyledMenu
-          open
-          id="combobox-menu"
-          anchorEl={anchorRef.current}
-          onClose={handleOnClose}
-          placement="bottom"
-          matchAnchorWidth
-        >
-          {'groups' in props ? (
-            <GroupedComboBoxMenu
-              {...props}
-              search={search}
-              itemRefs={itemRefs}
-              onItemSelect={handleOnItemSelect}
-              onItemKeyDown={handleOnItemKeyDown}
-            />
-          ) : (
-            <ComboBoxMenu
-              {...props}
-              search={search}
-              itemRefs={itemRefs}
-              onItemSelect={handleOnItemSelect}
-              onItemKeyDown={handleOnItemKeyDown}
-              selectableParent={
-                'values' in props ? props.selectableParent : false
-              }
-            />
-          )}
-        </StyledMenu>
-      )}
+      <StyledMenu
+        open={open}
+        id="combobox-menu"
+        data-testid="menu-list"
+        anchorEl={anchorRef.current}
+        onClose={handleOnClose}
+        placement="bottom"
+        matchAnchorWidth
+      >
+        {'groups' in props ? (
+          <GroupedComboBoxMenu
+            {...props}
+            search={search}
+            itemRefs={itemRefs}
+            onItemSelect={handleOnItemSelect}
+            onItemKeyDown={handleOnItemKeyDown}
+          />
+        ) : (
+          <ComboBoxMenu
+            {...props}
+            search={search}
+            itemRefs={itemRefs}
+            onItemSelect={handleOnItemSelect}
+            onItemKeyDown={handleOnItemKeyDown}
+            selectableParent={
+              'values' in props ? props.selectableParent : false
+            }
+          />
+        )}
+      </StyledMenu>
     </div>
   );
 };


### PR DESCRIPTION
This fixes a positioning bug that happens when the screen is resized or the user scrolls in certain scenarios.
Removes the conditional rendering of the `Menu` and passes the open state to menus `open` prop.

This is important since the `Menu` component uses the [useFloating hook](https://floating-ui.com/docs/usefloating#open). Which uses the `open` argument to check if the `Menu` has been positioned:

Before: 
![image](https://github.com/equinor/amplify-components/assets/25079611/f51dbecd-fc4b-4590-b11a-6753aa954901)

After: 
![image](https://github.com/equinor/amplify-components/assets/25079611/167e9b86-6259-4291-b80d-1d96dda1a066)
