### PR TITLE
fix: chip text alignment

### DIFF
--- a/src/components/DataDisplay/Chip/Chip.styles.tsx
+++ b/src/components/DataDisplay/Chip/Chip.styles.tsx
@@ -65,4 +65,10 @@ export const StyledChip = styled(Base)<ChipProps>`
             border: 1px solid ${getColorSchemeBy($variant).hover.borderColor};
           }
         `};
+  align-items: end;
+  line-height: 1.55em;
+  & > div,
+  svg {
+    align-self: center;
+  }
 `;


### PR DESCRIPTION
This pull-reuqest tries to fix the text alignemnt in the `Chip` component. It is not perfect for all types of chips but is overall much better. Getting them to align perfectily under all circumstances does not seem possible with how the base `Chip` has been implemented

before:
![image](https://github.com/equinor/amplify-components/assets/25079611/596f817f-f3b5-443f-82e5-410fcbd5fd0f)
after: 
![image](https://github.com/equinor/amplify-components/assets/25079611/0c825ce2-9981-4bd0-a3f3-d0f4c6ad621c)
