### PR TITLE
fix: changes from using name prop to data prop so that users dont need to load icon manually

### DIFF
--- a/src/components/DataDisplay/Chip/InteractiveChip.tsx
+++ b/src/components/DataDisplay/Chip/InteractiveChip.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, HTMLAttributes, KeyboardEvent, MouseEvent } from 'react';
 
 import { Icon } from '@equinor/eds-core-react';
+import { close } from '@equinor/eds-icons';
 
 import { BaseChipProps } from './Chip';
 import { InteractiveChipStyle } from './Chip.styles';
@@ -58,7 +59,7 @@ export const InteractiveChip = forwardRef<
           </div>
         )}
         {children}
-        {deletable && <Icon name="close" title="close" size={16} />}
+        {deletable && <Icon data={close} title="close" size={16} />}
       </div>
     </InteractiveChipStyle>
   );


### PR DESCRIPTION
This pull request fixes a breaking change in combox/chip component.

The current `InteractiveChip` is selecting the `close` icon by using the `name` prop.
This works in storybook and local dev mode since all of the icons gets loaded in `icon.stories.tsx` story using `Icon.add()`.
When building for production the loading of the icons get treeshaken out since the code is not imported by the user. Causing the `Chip` component to crash since there does not exist an icon named `close`.

Swaps the `InteractiveChip` from using the `name` to passing the `close`  icon to the `data` prop.