### PR TITLE
fix: stops icon from shrinking on smaller screens/containers and makes sure the icon is vertically centered

### DIFF
--- a/src/components/Inputs/EditableField.tsx
+++ b/src/components/Inputs/EditableField.tsx
@@ -20,6 +20,7 @@ interface ContainerProps {
 
 const Container = styled.div<ContainerProps>`
   display: flex;
+  align-items: center;
 
   &:hover {
     cursor: ${(props) => (props.$editable ? 'pointer' : undefined)};
@@ -33,6 +34,7 @@ const Container = styled.div<ContainerProps>`
 const Icon = styled(EdsIcon)`
   margin-left: ${spacings.small};
   height: 20px;
+  min-width: 24px;
 `;
 
 interface ITextFieldProps {
@@ -54,7 +56,7 @@ const TextField = styled(EdsTextField)<ITextFieldProps>`
         box-shadow: inset 0 -2px 0 0 ${colors.interactive.primary__resting.rgba};
       }
    }
-   
+
   `}
 
   div:focus-within {
@@ -140,6 +142,9 @@ const EditableField: React.FC<EditableFieldProps> = ({
           data-testid="editableicon"
           color={colors.interactive.primary__resting.rgba}
           data={edit}
+          style={{
+            minWidth: '24px',
+          }}
         />
       )}
     </Container>


### PR DESCRIPTION
This pull request fixes layout issues with the `EditableField` component. When the text becomes long or the container/screen gets small the edit icon shrink and the alignemnt of the the icon looks odd.

before:
![image](https://github.com/equinor/amplify-components/assets/25079611/08ae84dd-9fa7-47de-bc82-24367ee18b98)
![image](https://github.com/equinor/amplify-components/assets/25079611/cca4422f-92b3-4538-92cd-f343de59facd)

After:
![image](https://github.com/equinor/amplify-components/assets/25079611/3011f07f-1623-446b-b2e2-e37fcb4ec699)
![image](https://github.com/equinor/amplify-components/assets/25079611/4c1fce86-c928-4b0a-be2b-3226f6aea83f)

