### PR TITLE
fix: stop close button from shrinking ConfirmationPopup when the header text is long

### DIFF
--- a/src/components/Feedback/ConfirmationPopup.tsx
+++ b/src/components/Feedback/ConfirmationPopup.tsx
@@ -11,6 +11,10 @@ const StyledDialog = styled(Dialog)`
   min-width: 400px;
 `;
 
+const CloseButton = styled(Button)`
+  min-width: 40px;
+`;
+
 const DialogHeader = styled.div`
   display: flex;
   justify-content: space-between;
@@ -76,9 +80,9 @@ const ConfirmationPopup = forwardRef<HTMLDivElement, ConfirmationPopupProps>(
         >
           <DialogHeader data-testid="dialog-header">
             {title}
-            <Button variant="ghost_icon" onClick={onClose}>
+            <CloseButton variant="ghost_icon" onClick={onClose}>
               <Icon data={close} />
-            </Button>
+            </CloseButton>
           </DialogHeader>
           <Dialog.CustomContent>
             {body && <Typography variant="body_short">{body}</Typography>}


### PR DESCRIPTION
This pull request fixes an issue with `ConfirmationPopup` where to close button shrinks when the header text becomes to long by setting a `min-width` on the button. It is possible to set the width, but the header is often dynamic, referencing the name/title of a resource which can have a unknown length.

before:
![image](https://github.com/equinor/amplify-components/assets/25079611/2910f038-a635-4a0e-80b5-9c31c0a6a50d)

after:
![image](https://github.com/equinor/amplify-components/assets/25079611/b4456d72-e24b-4a99-97ed-46610cc8e9d7)
