### PR TITLE
fix: add type button to MenuButton

### DIFF
--- a/src/components/Inputs/RichTextEditor/MenuBar/MenuButton.tsx
+++ b/src/components/Inputs/RichTextEditor/MenuBar/MenuButton.tsx
@@ -86,6 +86,7 @@ const MenuButton = forwardRef<HTMLButtonElement, MenuButtonProps>(
       <Button
         ref={ref}
         $active={active}
+        type="button"
         $customColors={customColors}
         onClick={onClick}
         disabled={disabled}


### PR DESCRIPTION
This pull request fixes an issue where clicking the `MenuButton` submits forms if the `RichTextEditor` is used in a form.

Fixes the issue by adding `type="button"` to the `MenuButton`