### PR TITLE
fix: changes the text color for p tags and the background color to use

### DIFF
--- a/src/components/Inputs/RichTextEditor/RichTextEditor.styles.ts
+++ b/src/components/Inputs/RichTextEditor/RichTextEditor.styles.ts
@@ -17,7 +17,7 @@ export const Wrapper = styled.div<WrapperProps>`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  background: white;
+  background: ${colors.ui.background__default.rgba};
 
   border-radius: ${shape.corners.borderRadius} ${shape.corners.borderRadius} 0 0;
   border: ${(props) =>
@@ -73,7 +73,7 @@ export const Wrapper = styled.div<WrapperProps>`
     p {
       font-size: 16px;
       font-family: 'Equinor', sans-serif;
-      color: ${colors.text.static_icons__default.hex};
+      color: ${colors.text.static_icons__default.rgba};
       line-height: ${typography.paragraph.body_long.lineHeight};
       margin: 0;
     }
@@ -161,7 +161,7 @@ export const Wrapper = styled.div<WrapperProps>`
     }
   }
   .tiptap p.is-editor-empty:first-child::before {
-    color: #565656;
+    color: ${colors.text.static_icons__default.rgba};
     content: attr(data-placeholder);
     float: left;
     height: 0;


### PR DESCRIPTION
This pull request fixes an issue with the `RichTextEdtior` in dark mode. The text color for `p` tags and the background color was using hardcoded color. Fixed the issue by swapping the hardcoded colors for eds tokens.

before: 
![image](https://github.com/equinor/amplify-components/assets/25079611/3b29f558-5f11-4863-a0c1-7bfa41b3880a)

after:
![image](https://github.com/equinor/amplify-components/assets/25079611/bc00860d-65d0-4341-bdc4-318253cb38cf)
