### PR TITLE
fix: changes the placeholder color for RichTextEditor to match other input field color

### DIFF
--- a/src/components/Inputs/RichTextEditor/RichTextEditor.styles.ts
+++ b/src/components/Inputs/RichTextEditor/RichTextEditor.styles.ts
@@ -28,6 +28,10 @@ export const EditorStyling = styled.div<EditorStylingProps>`
     height: inherit;
   }
 
+  & [data-placeholder]::before {
+    color: ${colors.text.static_icons__tertiary.rgba} !important;
+  }
+
   .tiptap {
     max-height: ${(props) => props.$maxHeight ?? 'none'};
     overflow-y: auto;


### PR DESCRIPTION
This pull request changes the color of the placeholder text for the `RichTextEditor` to match the placeholder color of other eds/amplify input fields.

before: 
![image](https://github.com/equinor/amplify-components/assets/25079611/d38ed21f-b8ca-4110-a74e-fdbfe964201f)
![image](https://github.com/equinor/amplify-components/assets/25079611/961d1042-a02d-4323-87ca-fda90f9320bb)

after:
![image](https://github.com/equinor/amplify-components/assets/25079611/0fb1f40e-1519-4380-b673-88228b4718be)
![image](https://github.com/equinor/amplify-components/assets/25079611/8c600aab-ca69-47fc-86b2-0b2b93b22521)
