### PR TITLE
style: changes the height of the chip component so that they dont expand the combox when an item is selected

### DIFF
--- a/src/components/DataDisplay/Chip/Chip.styles.tsx
+++ b/src/components/DataDisplay/Chip/Chip.styles.tsx
@@ -135,19 +135,22 @@ const commonChipStyle = css`
   font-weight: 500;
   font-size: ${tokens.typography.ui.chip__badge.fontSize};
   line-height: 16px;
+  align-items: center;
   text-align: center;
   transition:
     background-color 150ms ease,
     border 150ms ease,
     color 150ms ease;
-  padding: ${tokens.spacings.comfortable.x_small};
-
+  padding: 0;
   .content {
-    padding: 0 ${tokens.spacings.comfortable.small};
+    padding-inline: ${tokens.spacings.comfortable.small};
+    padding-top: ${tokens.spacings.comfortable.xx_small};
     display: flex;
     align-items: center;
     gap: ${tokens.spacings.comfortable.x_small};
-
+    svg {
+      margin-top: -${tokens.spacings.comfortable.xx_small};
+    }
     .leading {
       display: flex;
       align-items: center;


### PR DESCRIPTION
This pull request fixes an issue whit the new `Chip` component. When it used in the `ComboBox` component. The height of the new `Chip` causes the `ComboBox` height to increase even when there is only one line. causing misaligment with other input field.
![image](https://github.com/equinor/amplify-components/assets/25079611/59c9edd9-6bfa-4ef0-9f8e-0314f17090dd)

before:
![Peek 2024-07-04 13-04](https://github.com/equinor/amplify-components/assets/25079611/6ae73f1b-979b-41e7-bfe1-c2591726f2f9)

after:
![Peek 2024-07-04 13-05](https://github.com/equinor/amplify-components/assets/25079611/abc263fa-1e94-4ff2-b2c6-f56291a904f2)
