### PR TITLE
🐛 Fix for tutorial card background dark mode

### DIFF
--- a/src/atoms/style/colors.ts
+++ b/src/atoms/style/colors.ts
@@ -14,6 +14,9 @@ export const colors = {
     background__heavy: {
       rgba: 'var(--amplify_ui_background_heavy, rgba(189, 189, 189, 1))',
     },
+    background__tutorial_card: {
+      rgba: 'var(--amplify_ui_background_tutorial_card, rgba(222, 237, 238, 1))',
+    },
   },
   interactive: {
     ...eds_colors.interactive,

--- a/src/atoms/style/darkTokens.ts
+++ b/src/atoms/style/darkTokens.ts
@@ -75,6 +75,7 @@ export const darkTokens = css`
     --eds_ui_background__light: rgba(38, 55, 68, 1);
     --amplify_ui_background_light_medium: rgba(40, 58, 72, 1);
     --amplify_ui_background_heavy: rgba(50, 72, 89, 1);
+    --amplify_ui_background_tutorial_card: rgba(50, 72, 89, 1);
     --eds_ui_background__scrim: rgba(0, 0, 0, 0.4);
     --eds_ui_background__overlay: rgba(0, 0, 0, 0.8);
     --eds_ui_background__medium: rgba(44, 64, 79, 1);

--- a/src/atoms/style/lightTokens.ts
+++ b/src/atoms/style/lightTokens.ts
@@ -4,6 +4,7 @@ export const lightTokens = css`
   [data-theme='light'] {
     --amplify_ui_background_light_medium: rgba(235, 235, 235, 1);
     --amplify_ui_background_heavy: rgba(189, 189, 189, 1);
+    --amplify_ui_background_tutorial_card: rgba(222, 237, 238, 1);
 
     --amplify_interactive_primary_pressed: rgba(19, 46, 49, 1);
 

--- a/src/providers/TutorialHighlightingProvider/TutorialPopover/TutorialPopover.tsx
+++ b/src/providers/TutorialHighlightingProvider/TutorialPopover/TutorialPopover.tsx
@@ -83,7 +83,7 @@ interface ContainerProps extends MotionProps {
 const Container = styled(motion(Card))<ContainerProps>`
   width: 360px;
   padding: ${spacings.medium};
-  background: ${colors.infographic.primary__moss_green_13.rgba};
+  background: ${colors.ui.background__tutorial_card.rgba};
   display: flex;
   flex-direction: column;
   gap: ${spacings.medium};
@@ -110,7 +110,7 @@ const Container = styled(motion(Card))<ContainerProps>`
         content: '';
         width: 32px;
         height: 32px;
-        background: ${colors.infographic.primary__moss_green_13.rgba};
+        background: ${colors.ui.background__tutorial_card.rgba};
         position: absolute;
         ${caretPositionToCss($caretPosition)}
       }


### PR DESCRIPTION
# Azure DevOps links
[AB#647528](https://dev.azure.com/Equinor/DPP%20Upscaling%20of%20digital%20solutions/_boards/board/t/Amplify%20Component%20Library/Stories?workitem=647528)

[] Needs to be tested locally by reviewer

# Description

Fixes tutorial card backgrounds using light mode color on dark mode. Set up a new css variable for them, named it the same as the figma variable name used on the design.

