### PR TITLE
:sparkles: Added "matchParentWidth" boolean prop to ToggleGroup

### DIFF
--- a/.idea/copilot.data.migration.agent.xml
+++ b/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.edit.xml
+++ b/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/src/organisms/ToggleGroup/ToggleGroup.stories.tsx
+++ b/src/organisms/ToggleGroup/ToggleGroup.stories.tsx
@@ -7,9 +7,7 @@ import { ToggleGroup as ToggleGroupProps } from './ToggleGroup.types';
 import { ToggleGroup as ToggleGroupComponent } from '.';
 import { colors } from 'src/atoms/style';
 
-interface StoryComponentProps {
-  variant: ToggleGroupProps['variant'];
-  matchParentHeight: ToggleGroupProps['matchParentHeight'];
+interface StoryComponentProps extends ToggleGroupProps {
   withIcons?: boolean;
   onlyIcons?: boolean;
   disabled?: boolean;
@@ -18,6 +16,7 @@ interface StoryComponentProps {
 const ToggleGroup: FC<StoryComponentProps> = ({
   variant,
   matchParentHeight,
+  matchParentWidth,
   withIcons = false,
   onlyIcons = false,
   disabled = false,
@@ -29,16 +28,20 @@ const ToggleGroup: FC<StoryComponentProps> = ({
   return (
     <div
       style={{
-        height: '48px',
-        outline: matchParentHeight
-          ? `1px solid ${colors.ui.background__medium.rgba}`
-          : undefined,
-        outlineOffset: matchParentHeight ? '10px' : undefined,
+        height: matchParentHeight ? '48px' : undefined,
+        width: matchParentWidth ? '100%' : undefined,
+        outline:
+          matchParentHeight || matchParentWidth
+            ? `1px solid ${colors.ui.background__medium.rgba}`
+            : undefined,
+        outlineOffset:
+          matchParentHeight || matchParentWidth ? '10px' : undefined,
       }}
     >
       <ToggleGroupComponent
         variant={variant}
         matchParentHeight={matchParentHeight}
+        matchParentWidth={matchParentWidth}
       >
         <ToggleGroupComponent.Option
           onToggle={setRecentlyPublished}
@@ -180,5 +183,12 @@ export const MatchParentHeight: Story = {
   args: {
     variant: 'outlined',
     matchParentHeight: true,
+  },
+};
+
+export const MatchParentWidth: Story = {
+  args: {
+    variant: 'outlined',
+    matchParentWidth: true,
   },
 };

--- a/src/organisms/ToggleGroup/ToggleGroup.test.tsx
+++ b/src/organisms/ToggleGroup/ToggleGroup.test.tsx
@@ -101,5 +101,29 @@ test('Match parent height works as expected', async () => {
     </div>
   );
 
-  expect(container.firstChild).toHaveStyle('height: 50px');
+  expect(container.firstChild?.firstChild).toHaveStyle('height: 50px');
+});
+
+test('Match parent width works as expected', async () => {
+  const options = new Array(faker.number.int({ min: 2, max: 3 }))
+    .fill(null)
+    .map(() => faker.vehicle.vehicle());
+  const handlers = options.map(() => vi.fn());
+  const { container } = render(
+    <div style={{ width: '500px' }}>
+      <ToggleGroup matchParentWidth>
+        {options.map((option, index) => (
+          <ToggleGroup.Option
+            key={option}
+            onToggle={handlers[index]}
+            label={option}
+            checked={false}
+          />
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+
+  expect(container.firstChild).toHaveStyle('width: 500px');
+  expect(container.firstChild?.firstChild).toHaveStyle('display: grid');
 });

--- a/src/organisms/ToggleGroup/ToggleGroup.tsx
+++ b/src/organisms/ToggleGroup/ToggleGroup.tsx
@@ -9,6 +9,7 @@ import styled, { css } from 'styled-components';
 interface WrapperProps {
   $variant: Required<ToggleGroupProps>['variant'];
   $matchParentHeight: Required<ToggleGroupProps>['matchParentHeight'];
+  $gridTemplateColumns?: string;
 }
 
 const Wrapper = styled.div<WrapperProps>`
@@ -51,15 +52,41 @@ const Wrapper = styled.div<WrapperProps>`
     }
     return '';
   }}
+  
+  ${({ $gridTemplateColumns }) => {
+    if (!$gridTemplateColumns) return '';
+
+    return css`
+      display: grid;
+      grid-template-columns: ${$gridTemplateColumns};
+
+      > button {
+        justify-content: center;
+      }
+    `;
+  }}
 `;
 
 export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
-  ({ variant = 'filled', matchParentHeight = false, children }, ref) => {
+  (
+    {
+      variant = 'filled',
+      matchParentHeight = false,
+      matchParentWidth = false,
+      children,
+    },
+    ref
+  ) => {
     return (
       <Wrapper
         ref={ref}
         $variant={variant}
         $matchParentHeight={matchParentHeight}
+        $gridTemplateColumns={
+          matchParentWidth
+            ? `repeat(${children.length}, minmax(0, 1fr))`
+            : undefined
+        }
       >
         {Children.map(children, (toggleOption) => {
           if (toggleOption.type != ToggleGroupOption) {

--- a/src/organisms/ToggleGroup/ToggleGroup.types.ts
+++ b/src/organisms/ToggleGroup/ToggleGroup.types.ts
@@ -25,5 +25,6 @@ export type ToggleGroupOption = {
 export interface ToggleGroup {
   variant?: 'filled' | 'outlined' | 'ghost';
   matchParentHeight?: boolean;
+  matchParentWidth?: boolean;
   children: ReactElement<ToggleGroupOption>[];
 }


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#667176](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/667176)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR adds `matchParentWidth` to ToggleGroup
