### PR TITLE
fix: change appicon name matching logic to lowercase both sides of th…

### DIFF
--- a/src/molecules/ApplicationIcon/ApplicationIcon.tsx
+++ b/src/molecules/ApplicationIcon/ApplicationIcon.tsx
@@ -101,9 +101,10 @@ export const ApplicationIcon = forwardRef<HTMLDivElement, ApplicationIconProps>(
     { name, size = 48, iconOnly = false, withHover = false, grayScale = false },
     ref
   ) => {
+    const lowerCaseName = name.toLowerCase();
     const appData = apps.find((app) =>
       app.appName.some(
-        (appNameToMatch) => appNameToMatch.toLowerCase() === name.toLowerCase()
+        (appNameToMatch) => appNameToMatch.toLowerCase() === lowerCaseName
       )
     );
 

--- a/src/molecules/ApplicationIcon/ApplicationIcon.tsx
+++ b/src/molecules/ApplicationIcon/ApplicationIcon.tsx
@@ -50,7 +50,10 @@ interface ApplicationIconData {
 }
 const apps: ApplicationIconData[] = [
   { appName: ['adca'], component: Adca },
-  { appName: ['portal', 'embark', 'jsembark'], component: JsEmbark },
+  {
+    appName: ['portal', 'embark', 'jsembark', 'js embark'],
+    component: JsEmbark,
+  },
   { appName: ['acquire'], component: Acquire },
   { appName: ['dasha'], component: Dasha },
   {
@@ -62,7 +65,10 @@ const apps: ApplicationIconData[] = [
     ],
     component: ForecastFormatter,
   },
-  { appName: ['fdi'], component: ForecastDataInventory },
+  {
+    appName: ['fdi', 'forecast data inventory'],
+    component: ForecastDataInventory,
+  },
   { appName: ['fluid-symphony', 'Fluid Symphony'], component: FluidSymphony },
   { appName: ['orca'], component: Orca },
   {
@@ -96,7 +102,9 @@ export const ApplicationIcon = forwardRef<HTMLDivElement, ApplicationIconProps>(
     ref
   ) => {
     const appData = apps.find((app) =>
-      app.appName.includes(name.toLowerCase())
+      app.appName.some(
+        (appNameToMatch) => appNameToMatch.toLowerCase() === name.toLowerCase()
+      )
     );
 
     if (appData === undefined)


### PR DESCRIPTION
…e match
---

- [ ] Needs to be tested locally by reviewer

# Description
Changes the appName matching logic to use `toLowerCase` on both sides of the matching. 

Fluid symphony was not working in SAM, because SAM passed in `Fluid Symphony` and applicationIcon had `['fluid-symphony', 'Fluid Symphony']` as matching options, but whatever you passed in was the only thing being made lowercase, so it tried to match `fluid symphony` and `Fluid Symphony`

I think this fix solves the problem, and avoids us having a hidden logic where you should write all the matching strings in lowercase to be sure it will always match correctly
<img width="778" height="681" alt="image" src="https://github.com/user-attachments/assets/8ecde84c-8279-437e-a28a-27160ef5b3c9" />
