### PR TITLE
fix: Tag height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-component-lib",
-  "version": "12.0.4",
+  "version": "12.0.5",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/molecules/Tag/Tag.tsx
+++ b/src/molecules/Tag/Tag.tsx
@@ -19,7 +19,7 @@ const Container = styled.div<ContainerProps>`
   padding: ${spacings.xx_small} ${spacings.x_small};
   gap: ${spacings.x_small};
   background: ${({ $color }) => TAG_COLORS[$color].background};
-  min-height: calc(24px + 2 * ${spacings.xx_small});
+  min-height: 24px;
   > span {
     color: ${({ $color }) => TAG_COLORS[$color].text};
     line-height: normal;


### PR DESCRIPTION
# Azure DevOps links

- [ ] Needs to be tested locally by reviewer

# Description

min-height in the Tag component was too big
