### PR TITLE
feat: support hiding content and jumping ahead on stepper

### DIFF
--- a/src/molecules/Stepper/Step/Step.tsx
+++ b/src/molecules/Stepper/Step/Step.tsx
@@ -43,12 +43,14 @@ interface StepProps {
   index: number;
   onlyShowCurrentStepLabel?: boolean;
   children?: string;
+  allowJumpingAhead?: boolean;
 }
 
 export const Step: FC<StepProps> = ({
   index,
   onlyShowCurrentStepLabel = false,
   children,
+  allowJumpingAhead = false,
 }) => {
   const { currentStep, setCurrentStep, isStepAtIndexDisabled } = useStepper();
 
@@ -56,17 +58,26 @@ export const Step: FC<StepProps> = ({
 
   const textVariant = useMemo((): TypographyVariants => {
     if (index < currentStep) return 'body_short';
+    if (allowJumpingAhead && index > currentStep) return 'body_short_bold';
     return 'body_short_bold';
-  }, [currentStep, index]);
+  }, [currentStep, index, allowJumpingAhead]);
 
   const textColor = useMemo((): string | undefined => {
-    if (index > currentStep || isDisabled)
+    if (isDisabled) return colors.interactive.disabled__text.rgba;
+    if (index > currentStep && !allowJumpingAhead)
       return colors.interactive.disabled__text.rgba;
     return colors.text.static_icons__default.rgba;
-  }, [currentStep, index, isDisabled]);
+  }, [currentStep, index, isDisabled, allowJumpingAhead]);
+
+  const isClickable = useMemo((): boolean => {
+    if (isDisabled) return false;
+    if (index < currentStep) return true;
+    if (allowJumpingAhead && index > currentStep) return true;
+    return false;
+  }, [index, currentStep, isDisabled, allowJumpingAhead]);
 
   const handleOnClick = () => {
-    if (index < currentStep && !isDisabled) {
+    if (isClickable) {
       setCurrentStep(index);
     }
   };
@@ -74,13 +85,17 @@ export const Step: FC<StepProps> = ({
   return (
     <Container
       data-testid="step"
-      $clickable={index < currentStep}
+      $clickable={isClickable}
       onClick={handleOnClick}
       $disabled={isDisabled}
       aria-disabled={isDisabled}
       role="button"
     >
-      <StepIcon index={index} disabled={isDisabled} />
+      <StepIcon
+        index={index}
+        disabled={isDisabled}
+        allowJumpingAhead={allowJumpingAhead}
+      />
       {(!onlyShowCurrentStepLabel || currentStep === index) && (
         <Typography variant={textVariant} color={textColor}>
           {children}

--- a/src/molecules/Stepper/Step/Step.tsx
+++ b/src/molecules/Stepper/Step/Step.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC, KeyboardEvent, useMemo } from 'react';
 
 import { Typography } from '@equinor/eds-core-react';
 import { TypographyVariants } from '@equinor/eds-core-react/dist/types/components/Typography/Typography.tokens';
@@ -82,14 +82,25 @@ export const Step: FC<StepProps> = ({
     }
   };
 
+  const handleOnKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!isClickable) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setCurrentStep(index);
+    }
+  };
+
   return (
     <Container
       data-testid="step"
       $clickable={isClickable}
       onClick={handleOnClick}
+      onKeyDown={handleOnKeyDown}
       $disabled={isDisabled}
-      aria-disabled={isDisabled}
+      aria-disabled={!isClickable}
       role="button"
+      tabIndex={isClickable ? 0 : -1}
     >
       <StepIcon
         index={index}

--- a/src/molecules/Stepper/Step/StepIcon.tsx
+++ b/src/molecules/Stepper/Step/StepIcon.tsx
@@ -30,10 +30,12 @@ const IconWrapper = styled.span<IconWrapperProps>`
   > p {
     // Ensure text icons are not squished
     padding: 8px;
-    color: ${(props) =>
-      props.$filled
+    color: ${({ $filled, $outlined }) =>
+      $filled
         ? colors.text.static_icons__primary_white.rgba
-        : colors.interactive.disabled__text.rgba};
+        : $outlined
+          ? colors.interactive.primary__resting.rgba
+          : colors.interactive.disabled__text.rgba};
   }
   > svg {
     transform: scale(0.9);
@@ -43,13 +45,26 @@ const IconWrapper = styled.span<IconWrapperProps>`
 interface StepIconProps {
   index: number;
   disabled?: boolean;
+  allowJumpingAhead?: boolean;
 }
 
-export const StepIcon: FC<StepIconProps> = ({ index, disabled }) => {
+export const StepIcon: FC<StepIconProps> = ({
+  index,
+  disabled,
+  allowJumpingAhead,
+}) => {
   const { currentStep } = useStepper();
 
   if (disabled) {
     return <Icon data={lock} color={colors.interactive.disabled__text.rgba} />;
+  }
+
+  if (index > currentStep && allowJumpingAhead) {
+    return (
+      <IconWrapper $outlined>
+        <Typography variant="caption">{index + 1}</Typography>
+      </IconWrapper>
+    );
   }
 
   if (index >= currentStep) {

--- a/src/molecules/Stepper/Stepper.jsdom.test.tsx
+++ b/src/molecules/Stepper/Stepper.jsdom.test.tsx
@@ -20,6 +20,9 @@ function fakeSteps(): StepperProviderProps['steps'] {
     {
       label: faker.string.uuid(),
     },
+    {
+      label: faker.string.uuid(),
+    },
   ];
   let i = 0;
   const stepAmount = faker.number.int({ min: 0, max: 30 });
@@ -96,5 +99,32 @@ test('maxWidth works as expected', async () => {
 
   expect(screen.getByTestId('stepper-container')).toHaveStyle(
     `max-width: ${maxWidth}`
+  );
+});
+
+test('Future step icon is outlined and primary when allowJumpingAhead is true', async () => {
+  const steps: StepperProviderProps['steps'] = [
+    { label: 'Step 1' },
+    { label: 'Step 2' },
+    { label: 'Step 3' },
+  ];
+
+  await renderWithRouter(
+    <StepperProvider steps={steps}>
+      <Stepper allowJumpingAhead />
+    </StepperProvider>,
+    {
+      routes: ['/'],
+      initialEntries: ['/'],
+    }
+  );
+
+  const secondStepButton = screen
+    .getByText('Step 2')
+    .closest('[data-testid="step"]');
+  const secondStepNumber = secondStepButton?.querySelector('p');
+
+  expect(secondStepNumber).toHaveStyle(
+    `color: ${colors.interactive.primary__resting.rgba}`
   );
 });

--- a/src/molecules/Stepper/Stepper.stories.tsx
+++ b/src/molecules/Stepper/Stepper.stories.tsx
@@ -1,12 +1,12 @@
 import { Button } from '@equinor/eds-core-react';
-import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { useLocation } from '@tanstack/react-router';
 
 import { spacings } from 'src/atoms/style';
 import { Stepper, StepperProps } from 'src/molecules/Stepper/Stepper';
 import { StepperProvider, useStepper } from 'src/providers/StepperProvider';
 
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent } from 'storybook/test';
 import styled from 'styled-components';
 
 const meta: Meta<typeof Stepper> = {
@@ -80,6 +80,8 @@ const meta: Meta<typeof Stepper> = {
 
 export default meta;
 
+type Story = StoryObj<typeof Stepper>;
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -104,7 +106,7 @@ const Container = styled.div`
   }
 `;
 
-export const Primary: StoryFn<StepperProps> = (args) => {
+const PrimaryTemplate = (args: StepperProps) => {
   const { steps, goToNextStep, goToPreviousStep, currentStep } = useStepper();
 
   return (
@@ -127,6 +129,24 @@ export const Primary: StoryFn<StepperProps> = (args) => {
       </section>
     </Container>
   );
+};
+
+export const Primary: Story = {
+  render: (args) => <PrimaryTemplate {...args} />,
+};
+
+export const TestPrimary: Story = {
+  tags: ['test-only'],
+  render: (args) => <PrimaryTemplate {...args} />,
+  play: async ({ canvas, step }) => {
+    await step('Future steps are not clickable by default', async () => {
+      await userEvent.click(
+        canvas.getByRole('button', { name: /Finish order/i })
+      );
+
+      await expect(canvas.getByRole('button', { name: 'Next' })).toBeEnabled();
+    });
+  },
 };
 
 const Story = (args: StepperProps) => {
@@ -162,7 +182,7 @@ const Story = (args: StepperProps) => {
   );
 };
 
-export const SyncedToURL: StoryObj = {
+export const SyncedToURL: Story = {
   parameters: {
     syncToURL: true,
     router: {
@@ -171,18 +191,32 @@ export const SyncedToURL: StoryObj = {
     },
   },
   render: () => <Story />,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+};
 
-    await expect(
-      canvas.getByText(`Current path: /create/0`)
-    ).toBeInTheDocument();
+export const TestSyncedToURL: Story = {
+  tags: ['test-only'],
+  parameters: {
+    syncToURL: true,
+    router: {
+      initial: '/create/0',
+      routes: ['/create/$step'],
+    },
+  },
+  render: () => <Story />,
+  play: async ({ canvas, step }) => {
+    await step('Initial URL path is rendered', async () => {
+      await expect(
+        canvas.getByText(`Current path: /create/0`)
+      ).toBeInTheDocument();
+    });
 
-    await userEvent.click(canvas.getByText('Next'));
+    await step('Next updates URL param', async () => {
+      await userEvent.click(canvas.getByText('Next'));
 
-    await expect(
-      canvas.getByText(`Current path: /create/1`)
-    ).toBeInTheDocument();
+      await expect(
+        canvas.getByText(`Current path: /create/1`)
+      ).toBeInTheDocument();
+    });
   },
 };
 
@@ -196,7 +230,7 @@ function isStepDisabled({
   return stepIndex < currentStepIndex;
 }
 
-export const DisabledSteps: StoryObj = {
+export const DisabledSteps: Story = {
   parameters: {
     syncToURL: true,
     disabledSteps: true,
@@ -208,7 +242,7 @@ export const DisabledSteps: StoryObj = {
   render: () => <Story />,
 };
 
-export const HideContent: StoryFn<StepperProps> = (args) => {
+const HideContentTemplate = (args: StepperProps) => {
   const { steps, goToNextStep, goToPreviousStep, currentStep } = useStepper();
 
   return (
@@ -233,16 +267,35 @@ export const HideContent: StoryFn<StepperProps> = (args) => {
   );
 };
 
-HideContent.parameters = {
-  docs: {
-    description: {
-      story:
-        'Hides the SubTitle content panel, containing the step title and description, while keeping step indicators and navigation behavior intact.',
+export const HideContent: Story = {
+  render: (args) => <HideContentTemplate {...args} hideContent />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hides the SubTitle content panel, containing the step title and description, while keeping step indicators and navigation behavior intact.',
+      },
     },
   },
 };
 
-export const AllowJumpingAhead: StoryFn<StepperProps> = (args) => {
+export const TestHideContent: Story = {
+  tags: ['test-only'],
+  render: (args) => <HideContentTemplate {...args} hideContent />,
+  play: async ({ canvas, step }) => {
+    await step(
+      'SubTitle content is hidden while labels remain visible',
+      async () => {
+        await expect(
+          canvas.queryByText('Help us select  a car type for you')
+        ).not.toBeInTheDocument();
+        await expect(canvas.getByText('Select car type')).toBeInTheDocument();
+      }
+    );
+  },
+};
+
+const AllowJumpingAheadTemplate = (args: StepperProps) => {
   const { steps, goToNextStep, goToPreviousStep, currentStep } = useStepper();
 
   return (
@@ -267,20 +320,41 @@ export const AllowJumpingAhead: StoryFn<StepperProps> = (args) => {
   );
 };
 
-AllowJumpingAhead.parameters = {
-  docs: {
-    description: {
-      story:
-        'Allows selecting future steps directly. Future step labels/icons are rendered as interactive rather than disabled.',
+export const AllowJumpingAhead: Story = {
+  render: (args) => <AllowJumpingAheadTemplate {...args} allowJumpingAhead />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Allows selecting future steps directly. Future step labels/icons are rendered as interactive rather than disabled.',
+      },
     },
   },
 };
 
-AllowJumpingAhead.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
+export const TestAllowJumpingAhead: Story = {
+  tags: ['test-only'],
+  render: (args) => <AllowJumpingAheadTemplate {...args} allowJumpingAhead />,
+  play: async ({ canvas, step }) => {
+    await step('Clicking future step jumps directly', async () => {
+      await userEvent.click(
+        canvas.getByRole('button', { name: /Finish order/i })
+      );
 
-  await userEvent.click(canvas.getByRole('button', { name: '3 Finish order' }));
+      await expect(canvas.getByRole('button', { name: 'Next' })).toBeDisabled();
+      await expect(
+        canvas.getByRole('button', { name: 'Previous' })
+      ).toBeEnabled();
+    });
 
-  await expect(canvas.getByRole('button', { name: 'Next' })).toBeDisabled();
-  await expect(canvas.getByRole('button', { name: 'Previous' })).toBeEnabled();
+    await step('Keyboard interaction also supports jumping', async () => {
+      const selectCarModel = canvas.getByRole('button', {
+        name: /Select car model/i,
+      });
+      selectCarModel.focus();
+      await userEvent.keyboard('{Enter}');
+
+      await expect(canvas.getByRole('button', { name: 'Next' })).toBeEnabled();
+    });
+  },
 };

--- a/src/molecules/Stepper/Stepper.stories.tsx
+++ b/src/molecules/Stepper/Stepper.stories.tsx
@@ -247,7 +247,7 @@ const HideContentTemplate = (args: StepperProps) => {
 
   return (
     <Container>
-      <Stepper {...args} hideContent />
+      <Stepper {...args} />
       <section>
         <Button
           variant="outlined"
@@ -268,7 +268,10 @@ const HideContentTemplate = (args: StepperProps) => {
 };
 
 export const HideContent: Story = {
-  render: (args) => <HideContentTemplate {...args} hideContent />,
+  args: {
+    hideContent: true,
+  },
+  render: (args) => <HideContentTemplate {...args} />,
   parameters: {
     docs: {
       description: {
@@ -281,7 +284,10 @@ export const HideContent: Story = {
 
 export const TestHideContent: Story = {
   tags: ['test-only'],
-  render: (args) => <HideContentTemplate {...args} hideContent />,
+  args: {
+    hideContent: true,
+  },
+  render: (args) => <HideContentTemplate {...args} />,
   play: async ({ canvas, step }) => {
     await step(
       'SubTitle content is hidden while labels remain visible',
@@ -300,7 +306,7 @@ const AllowJumpingAheadTemplate = (args: StepperProps) => {
 
   return (
     <Container>
-      <Stepper {...args} allowJumpingAhead />
+      <Stepper {...args} />
       <section>
         <Button
           variant="outlined"
@@ -321,7 +327,10 @@ const AllowJumpingAheadTemplate = (args: StepperProps) => {
 };
 
 export const AllowJumpingAhead: Story = {
-  render: (args) => <AllowJumpingAheadTemplate {...args} allowJumpingAhead />,
+  args: {
+    allowJumpingAhead: true,
+  },
+  render: (args) => <AllowJumpingAheadTemplate {...args} />,
   parameters: {
     docs: {
       description: {
@@ -334,7 +343,10 @@ export const AllowJumpingAhead: Story = {
 
 export const TestAllowJumpingAhead: Story = {
   tags: ['test-only'],
-  render: (args) => <AllowJumpingAheadTemplate {...args} allowJumpingAhead />,
+  args: {
+    allowJumpingAhead: true,
+  },
+  render: (args) => <AllowJumpingAheadTemplate {...args} />,
   play: async ({ canvas, step }) => {
     await step('Clicking future step jumps directly', async () => {
       await userEvent.click(

--- a/src/molecules/Stepper/Stepper.stories.tsx
+++ b/src/molecules/Stepper/Stepper.stories.tsx
@@ -15,11 +15,21 @@ const meta: Meta<typeof Stepper> = {
   argTypes: {
     onlyShowCurrentStepLabel: { control: 'boolean' },
     maxWidth: { control: 'text' },
+    hideContent: { control: 'boolean' },
+    allowJumpingAhead: { control: 'boolean' },
   },
   args: {
     onlyShowCurrentStepLabel: false,
+    hideContent: false,
+    allowJumpingAhead: false,
   },
   parameters: {
+    docs: {
+      description: {
+        component:
+          'Navigation buttons in these stories are helper controls for demonstration only and are not part of the Stepper component.',
+      },
+    },
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/fk8AI59x5HqPCBg4Nemlkl/%F0%9F%92%A0-Component-Library---Amplify?node-id=5694-19911&m=dev',
@@ -77,9 +87,20 @@ const Container = styled.div`
   padding: 0 10rem;
   > section {
     display: flex;
+    align-items: center;
     justify-content: flex-end;
     margin-top: ${spacings.xxx_large};
     gap: ${spacings.medium};
+    padding-top: ${spacings.medium};
+    border-top: 2px solid #e0e0e0;
+
+    &::before {
+      content: 'Story Navigation (not part of component):';
+      margin-right: auto;
+      font-size: 12px;
+      color: #888;
+      font-weight: 500;
+    }
   }
 `;
 
@@ -185,4 +206,81 @@ export const DisabledSteps: StoryObj = {
     },
   },
   render: () => <Story />,
+};
+
+export const HideContent: StoryFn<StepperProps> = (args) => {
+  const { steps, goToNextStep, goToPreviousStep, currentStep } = useStepper();
+
+  return (
+    <Container>
+      <Stepper {...args} hideContent />
+      <section>
+        <Button
+          variant="outlined"
+          onClick={goToPreviousStep}
+          disabled={currentStep === 0}
+        >
+          Previous
+        </Button>
+        <Button
+          onClick={goToNextStep}
+          disabled={currentStep === steps.length - 1}
+        >
+          Next
+        </Button>
+      </section>
+    </Container>
+  );
+};
+
+HideContent.parameters = {
+  docs: {
+    description: {
+      story:
+        'Hides the SubTitle content panel, containing the step title and description, while keeping step indicators and navigation behavior intact.',
+    },
+  },
+};
+
+export const AllowJumpingAhead: StoryFn<StepperProps> = (args) => {
+  const { steps, goToNextStep, goToPreviousStep, currentStep } = useStepper();
+
+  return (
+    <Container>
+      <Stepper {...args} allowJumpingAhead />
+      <section>
+        <Button
+          variant="outlined"
+          onClick={goToPreviousStep}
+          disabled={currentStep === 0}
+        >
+          Previous
+        </Button>
+        <Button
+          onClick={goToNextStep}
+          disabled={currentStep === steps.length - 1}
+        >
+          Next
+        </Button>
+      </section>
+    </Container>
+  );
+};
+
+AllowJumpingAhead.parameters = {
+  docs: {
+    description: {
+      story:
+        'Allows selecting future steps directly. Future step labels/icons are rendered as interactive rather than disabled.',
+    },
+  },
+};
+
+AllowJumpingAhead.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  await userEvent.click(canvas.getByRole('button', { name: '3 Finish order' }));
+
+  await expect(canvas.getByRole('button', { name: 'Next' })).toBeDisabled();
+  await expect(canvas.getByRole('button', { name: 'Previous' })).toBeEnabled();
 };

--- a/src/molecules/Stepper/Stepper.test.tsx
+++ b/src/molecules/Stepper/Stepper.test.tsx
@@ -264,3 +264,111 @@ test('Disabled steps work as expected', async () => {
   expect(firstStep).toBeInTheDocument();
   expect(firstStep).toBeDisabled();
 });
+
+test('hideContent prop hides the SubTitle component', async () => {
+  const steps: StepperProviderProps['steps'] = [
+    {
+      label: 'Step 1',
+      title: 'Test Title',
+      description: 'Test Description',
+    },
+    {
+      label: 'Step 2',
+    },
+  ];
+  renderWithRouter(
+    <StepperProvider steps={steps}>
+      <StepperTestComponent hideContent />
+    </StepperProvider>,
+    {
+      initialEntries: ['/'],
+      routes: ['/'],
+    }
+  );
+
+  // The subtitle text should not be visible when hideContent is true
+  expect(screen.queryByText('Test Title')).not.toBeInTheDocument();
+  expect(screen.queryByText('Test Description')).not.toBeInTheDocument();
+
+  // But the step labels should still be visible
+  expect(await screen.findByText(steps[0].label)).toBeInTheDocument();
+  expect(screen.getByText(steps[1].label)).toBeInTheDocument();
+});
+
+test('hideContent defaults to false, showing SubTitle', async () => {
+  const steps: StepperProviderProps['steps'] = [
+    {
+      label: 'Step 1',
+      title: 'Test Title',
+      description: 'Test Description',
+    },
+    {
+      label: 'Step 2',
+    },
+  ];
+  renderWithRouter(
+    <StepperProvider steps={steps}>
+      <StepperTestComponent />
+    </StepperProvider>,
+    {
+      initialEntries: ['/'],
+      routes: ['/'],
+    }
+  );
+
+  // When hideContent is not set, SubTitle should be visible
+  expect(await screen.findByText('Test Title')).toBeInTheDocument();
+  expect(screen.getByText('Test Description')).toBeInTheDocument();
+});
+
+test('allowJumpingAhead allows clicking forward to future steps', async () => {
+  const steps = fakeSteps();
+  renderWithRouter(
+    <StepperProvider steps={steps}>
+      <StepperTestComponent allowJumpingAhead />
+    </StepperProvider>,
+    {
+      initialEntries: ['/'],
+      routes: ['/'],
+    }
+  );
+
+  const user = userEvent.setup();
+
+  expect(await screen.findByText(`Current step: 0`)).toBeInTheDocument();
+
+  // Click on a step that is ahead of the current step
+  const thirdStepLabel = steps[2].label;
+  await user.click(screen.getByText(thirdStepLabel));
+
+  // Should now be on step 2
+  expect(screen.getByText(`Current step: 2`)).toBeInTheDocument();
+});
+
+test('allowJumpingAhead defaults to false, preventing forward jumps', async () => {
+  const steps = fakeSteps();
+  renderWithRouter(
+    <StepperProvider steps={steps}>
+      <StepperTestComponent />
+    </StepperProvider>,
+    {
+      initialEntries: ['/'],
+      routes: ['/'],
+    }
+  );
+
+  const user = userEvent.setup();
+
+  expect(await screen.findByText(`Current step: 0`)).toBeInTheDocument();
+
+  // Try to click on a step that is ahead
+  const thirdStepLabel = steps[2].label;
+  const thirdStepElement = screen
+    .getByText(thirdStepLabel)
+    .closest('[role="button"]');
+
+  await user.click(thirdStepElement!);
+
+  // Should still be on step 0 (the click should not have worked)
+  expect(screen.getByText(`Current step: 0`)).toBeInTheDocument();
+});

--- a/src/molecules/Stepper/Stepper.test.tsx
+++ b/src/molecules/Stepper/Stepper.test.tsx
@@ -23,6 +23,9 @@ function fakeSteps(): StepperProviderProps['steps'] {
     {
       label: faker.string.uuid(),
     },
+    {
+      label: faker.string.uuid(),
+    },
   ];
   let i = 0;
   const stepAmount = faker.number.int({ min: 0, max: 30 });
@@ -265,64 +268,21 @@ test('Disabled steps work as expected', async () => {
   expect(firstStep).toBeDisabled();
 });
 
-test('hideContent prop hides the SubTitle component', async () => {
+test('jumping ahead resets substep index on destination step', async () => {
   const steps: StepperProviderProps['steps'] = [
     {
       label: 'Step 1',
-      title: 'Test Title',
-      description: 'Test Description',
+      subSteps: [{ title: 'Step 1 Substep A' }, { title: 'Step 1 Substep B' }],
     },
     {
       label: 'Step 2',
+      subSteps: [{ title: 'Step 2 Substep A' }],
+    },
+    {
+      label: 'Step 3',
     },
   ];
-  renderWithRouter(
-    <StepperProvider steps={steps}>
-      <StepperTestComponent hideContent />
-    </StepperProvider>,
-    {
-      initialEntries: ['/'],
-      routes: ['/'],
-    }
-  );
 
-  // The subtitle text should not be visible when hideContent is true
-  expect(screen.queryByText('Test Title')).not.toBeInTheDocument();
-  expect(screen.queryByText('Test Description')).not.toBeInTheDocument();
-
-  // But the step labels should still be visible
-  expect(await screen.findByText(steps[0].label)).toBeInTheDocument();
-  expect(screen.getByText(steps[1].label)).toBeInTheDocument();
-});
-
-test('hideContent defaults to false, showing SubTitle', async () => {
-  const steps: StepperProviderProps['steps'] = [
-    {
-      label: 'Step 1',
-      title: 'Test Title',
-      description: 'Test Description',
-    },
-    {
-      label: 'Step 2',
-    },
-  ];
-  renderWithRouter(
-    <StepperProvider steps={steps}>
-      <StepperTestComponent />
-    </StepperProvider>,
-    {
-      initialEntries: ['/'],
-      routes: ['/'],
-    }
-  );
-
-  // When hideContent is not set, SubTitle should be visible
-  expect(await screen.findByText('Test Title')).toBeInTheDocument();
-  expect(screen.getByText('Test Description')).toBeInTheDocument();
-});
-
-test('allowJumpingAhead allows clicking forward to future steps', async () => {
-  const steps = fakeSteps();
   renderWithRouter(
     <StepperProvider steps={steps}>
       <StepperTestComponent allowJumpingAhead />
@@ -335,40 +295,13 @@ test('allowJumpingAhead allows clicking forward to future steps', async () => {
 
   const user = userEvent.setup();
 
-  expect(await screen.findByText(`Current step: 0`)).toBeInTheDocument();
+  expect(await screen.findByText('Step 1 Substep A')).toBeInTheDocument();
 
-  // Click on a step that is ahead of the current step
-  const thirdStepLabel = steps[2].label;
-  await user.click(screen.getByText(thirdStepLabel));
+  await user.click(screen.getByText('Next'));
+  expect(screen.getByText('Step 1 Substep B')).toBeInTheDocument();
 
-  // Should now be on step 2
-  expect(screen.getByText(`Current step: 2`)).toBeInTheDocument();
-});
+  await user.click(screen.getByText('Step 2'));
 
-test('allowJumpingAhead defaults to false, preventing forward jumps', async () => {
-  const steps = fakeSteps();
-  renderWithRouter(
-    <StepperProvider steps={steps}>
-      <StepperTestComponent />
-    </StepperProvider>,
-    {
-      initialEntries: ['/'],
-      routes: ['/'],
-    }
-  );
-
-  const user = userEvent.setup();
-
-  expect(await screen.findByText(`Current step: 0`)).toBeInTheDocument();
-
-  // Try to click on a step that is ahead
-  const thirdStepLabel = steps[2].label;
-  const thirdStepElement = screen
-    .getByText(thirdStepLabel)
-    .closest('[role="button"]');
-
-  await user.click(thirdStepElement!);
-
-  // Should still be on step 0 (the click should not have worked)
-  expect(screen.getByText(`Current step: 0`)).toBeInTheDocument();
+  expect(screen.getByText('Current step: 1')).toBeInTheDocument();
+  expect(screen.getByText('Step 2 Substep A')).toBeInTheDocument();
 });

--- a/src/molecules/Stepper/Stepper.tsx
+++ b/src/molecules/Stepper/Stepper.tsx
@@ -8,6 +8,37 @@ import { useStepper } from 'src/providers/StepperProvider';
 
 import styled, { css } from 'styled-components';
 
+/**
+ * Stepper component that displays a multi-step process with visual progress indication.
+ *
+ * The Stepper component renders step labels with connecting lines and displays
+ * the current step's content (title and description) via the SubTitle component.
+ * SubTitle content is available when a step has a `title` or `subSteps`.
+ * It relies on the StepperProvider for state management and step configuration.
+ *
+ * @component
+ * @example
+ * // Basic usage within a StepperProvider
+ * <StepperProvider steps={steps}>
+ *   <Stepper />
+ * </StepperProvider>
+ *
+ * @example
+ * // Only show the current step's label
+ * <Stepper onlyShowCurrentStepLabel />
+ *
+ * @example
+ * // Hide the content section
+ * <Stepper hideContent />
+ *
+ * @example
+ * // Allow users to jump to any step
+ * <Stepper allowJumpingAhead />
+ *
+ * @param props - The component props
+ * @returns The rendered Stepper component
+ */
+
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -36,14 +67,26 @@ const Container = styled.div<ContainerProps>`
   }}
 `;
 
+/**
+ * Props for the Stepper component
+ * @interface StepperProps
+ */
 export interface StepperProps {
+  /** If true, only the current step's label is displayed, hiding others */
   onlyShowCurrentStepLabel?: boolean;
+  /** Maximum width of the stepper container */
   maxWidth?: string;
+  /** If true, hides the SubTitle content section below the stepper (used when steps provide `title` or `subSteps`) */
+  hideContent?: boolean;
+  /** If true, allows users to click on steps ahead of the current step to jump forward and renders those steps as interactive */
+  allowJumpingAhead?: boolean;
 }
 
 export const Stepper: FC<StepperProps> = ({
   onlyShowCurrentStepLabel = false,
   maxWidth,
+  hideContent = false,
+  allowJumpingAhead = false,
 }) => {
   const { steps, currentStep } = useStepper();
 
@@ -55,6 +98,7 @@ export const Stepper: FC<StepperProps> = ({
           key={`step-${index}`}
           index={index}
           onlyShowCurrentStepLabel={onlyShowCurrentStepLabel}
+          allowJumpingAhead={allowJumpingAhead}
         >
           {step.label}
         </Step>
@@ -62,12 +106,15 @@ export const Stepper: FC<StepperProps> = ({
 
       if (index !== steps.length - 1) {
         all.push(
-          <StepLine key={`step-line-${index}`} done={currentStep > index} />
+          <StepLine
+            key={`step-line-${index}`}
+            done={currentStep > index || allowJumpingAhead}
+          />
         );
       }
     });
     return all;
-  }, [currentStep, onlyShowCurrentStepLabel, steps]);
+  }, [currentStep, onlyShowCurrentStepLabel, steps, allowJumpingAhead]);
 
   return (
     <Wrapper>
@@ -78,7 +125,7 @@ export const Stepper: FC<StepperProps> = ({
       >
         {content}
       </Container>
-      <SubTitle />
+      {!hideContent && <SubTitle />}
     </Wrapper>
   );
 };

--- a/src/providers/StepperProvider.jsdom.test.tsx
+++ b/src/providers/StepperProvider.jsdom.test.tsx
@@ -1,5 +1,5 @@
-import { renderHook } from '@testing-library/react';
 import { useLocation } from '@tanstack/react-router';
+import { renderHook } from '@testing-library/react';
 
 import { StepperProvider, useStepper } from 'src/providers/StepperProvider';
 import { renderWithRouter, screen, userEvent } from 'src/tests/jsdomtest-utils';
@@ -227,10 +227,7 @@ test('Setting the current step to the current value keeps substep unchanged', as
 test('Going to the next step from the last step does nothing', async () => {
   await renderWithRouter(
     <StepperProvider
-      steps={[
-        { label: 'step 1' },
-        { label: 'step 2' },
-      ]}
+      steps={[{ label: 'step 1' }, { label: 'step 2' }]}
       initialStep={1}
     >
       <StepperProviderTestHarness />
@@ -246,12 +243,7 @@ test('Going to the next step from the last step does nothing', async () => {
 
 test('Going to the next step advances when not on the last step', async () => {
   await renderWithRouter(
-    <StepperProvider
-      steps={[
-        { label: 'step 1' },
-        { label: 'step 2' },
-      ]}
-    >
+    <StepperProvider steps={[{ label: 'step 1' }, { label: 'step 2' }]}>
       <StepperProviderTestHarness />
     </StepperProvider>
   );
@@ -291,12 +283,7 @@ test('Going previous from a substep decrements the current substep', async () =>
 
 test('Going previous from the first step does nothing', async () => {
   await renderWithRouter(
-    <StepperProvider
-      steps={[
-        { label: 'step 1' },
-        { label: 'step 2' },
-      ]}
-    >
+    <StepperProvider steps={[{ label: 'step 1' }, { label: 'step 2' }]}>
       <StepperProviderTestHarness />
     </StepperProvider>
   );
@@ -311,10 +298,7 @@ test('Going previous from the first step does nothing', async () => {
 test('Going previous from a later step moves to the previous step', async () => {
   await renderWithRouter(
     <StepperProvider
-      steps={[
-        { label: 'step 1' },
-        { label: 'step 2' },
-      ]}
+      steps={[{ label: 'step 1' }, { label: 'step 2' }]}
       initialStep={1}
     >
       <StepperProviderTestHarness />
@@ -360,10 +344,7 @@ test('syncToURLParam navigates when setting the current step', async () => {
   await renderWithRouter(
     <StepperProvider
       syncToURLParam
-      steps={[
-        { label: 'step 1' },
-        { label: 'step 2' },
-      ]}
+      steps={[{ label: 'step 1' }, { label: 'step 2' }]}
     >
       <StepperProviderLocationHarness />
     </StepperProvider>,
@@ -384,10 +365,7 @@ test('syncToURLParam navigates when setting the current step', async () => {
 test('isStepAtIndexDisabled returns callback result', async () => {
   await renderWithRouter(
     <StepperProvider
-      steps={[
-        { label: 'step 1' },
-        { label: 'step 2' },
-      ]}
+      steps={[{ label: 'step 1' }, { label: 'step 2' }]}
       isStepDisabled={({ stepIndex }) => stepIndex === 0}
     >
       <StepperProviderTestHarness />

--- a/src/providers/StepperProvider.jsdom.test.tsx
+++ b/src/providers/StepperProvider.jsdom.test.tsx
@@ -1,7 +1,48 @@
 import { renderHook } from '@testing-library/react';
+import { useLocation } from '@tanstack/react-router';
 
 import { StepperProvider, useStepper } from 'src/providers/StepperProvider';
-import { renderWithRouter } from 'src/tests/jsdomtest-utils';
+import { renderWithRouter, screen, userEvent } from 'src/tests/jsdomtest-utils';
+
+function StepperProviderTestHarness() {
+  const {
+    currentStep,
+    currentSubStep,
+    goToNextStep,
+    goToPreviousStep,
+    setCurrentStep,
+    isStepAtIndexDisabled,
+  } = useStepper();
+
+  return (
+    <div>
+      <p>{`Current step: ${currentStep}`}</p>
+      <p>{`Current substep: ${currentSubStep}`}</p>
+      <p>{`Step 0 disabled: ${isStepAtIndexDisabled(0)}`}</p>
+      <p>{`Step 1 disabled: ${isStepAtIndexDisabled(1)}`}</p>
+      <button onClick={goToNextStep}>Next</button>
+      <button onClick={goToPreviousStep}>Previous</button>
+      <button onClick={() => setCurrentStep(0)}>Go to step 0</button>
+      <button onClick={() => setCurrentStep(1)}>Go to step 1</button>
+      <button onClick={() => setCurrentStep(currentStep)}>
+        Set current step
+      </button>
+    </div>
+  );
+}
+
+function StepperProviderLocationHarness() {
+  const { pathname } = useLocation();
+  const { currentStep, setCurrentStep } = useStepper();
+
+  return (
+    <div>
+      <p>{`Current step: ${currentStep}`}</p>
+      <p>{`Current path: ${pathname}`}</p>
+      <button onClick={() => setCurrentStep(1)}>Go to step 1</button>
+    </div>
+  );
+}
 
 test('"useStepper" throws error if used outside of provider', async () => {
   console.error = vi.fn();
@@ -95,4 +136,264 @@ test('Providing less than 2 steps throws error', async () => {
   );
 
   expect(spy).toHaveBeenCalled();
+});
+
+test('Direct step changes reset substep to 0 when moving forward', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        {
+          label: 'step 1',
+          subSteps: [{ title: 'first' }, { title: 'second' }],
+        },
+        {
+          label: 'step 2',
+          subSteps: [{ title: 'destination' }],
+        },
+      ]}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Next'));
+  expect(screen.getByText('Current substep: 1')).toBeInTheDocument();
+
+  await user.click(screen.getByText('Go to step 1'));
+
+  expect(screen.getByText('Current step: 1')).toBeInTheDocument();
+  expect(screen.getByText('Current substep: 0')).toBeInTheDocument();
+});
+
+test('Direct step changes move to last substep when moving backward', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        {
+          label: 'step 1',
+          subSteps: [{ title: 'first' }, { title: 'second' }],
+        },
+        {
+          label: 'step 2',
+        },
+        {
+          label: 'step 3',
+        },
+      ]}
+      initialStep={2}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Go to step 0'));
+
+  expect(screen.getByText('Current step: 0')).toBeInTheDocument();
+  expect(screen.getByText('Current substep: 1')).toBeInTheDocument();
+});
+
+test('Setting the current step to the current value keeps substep unchanged', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        {
+          label: 'step 1',
+          subSteps: [{ title: 'first' }, { title: 'second' }],
+        },
+        {
+          label: 'step 2',
+        },
+      ]}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Next'));
+  expect(screen.getByText('Current substep: 1')).toBeInTheDocument();
+
+  await user.click(screen.getByText('Set current step'));
+
+  expect(screen.getByText('Current step: 0')).toBeInTheDocument();
+  expect(screen.getByText('Current substep: 1')).toBeInTheDocument();
+});
+
+test('Going to the next step from the last step does nothing', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        { label: 'step 1' },
+        { label: 'step 2' },
+      ]}
+      initialStep={1}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Next'));
+
+  expect(screen.getByText('Current step: 1')).toBeInTheDocument();
+});
+
+test('Going to the next step advances when not on the last step', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        { label: 'step 1' },
+        { label: 'step 2' },
+      ]}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Next'));
+
+  expect(screen.getByText('Current step: 1')).toBeInTheDocument();
+});
+
+test('Going previous from a substep decrements the current substep', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        {
+          label: 'step 1',
+          subSteps: [{ title: 'first' }, { title: 'second' }],
+        },
+        { label: 'step 2' },
+      ]}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Next'));
+  expect(screen.getByText('Current substep: 1')).toBeInTheDocument();
+
+  await user.click(screen.getByText('Previous'));
+
+  expect(screen.getByText('Current step: 0')).toBeInTheDocument();
+  expect(screen.getByText('Current substep: 0')).toBeInTheDocument();
+});
+
+test('Going previous from the first step does nothing', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        { label: 'step 1' },
+        { label: 'step 2' },
+      ]}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Previous'));
+
+  expect(screen.getByText('Current step: 0')).toBeInTheDocument();
+});
+
+test('Going previous from a later step moves to the previous step', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        { label: 'step 1' },
+        { label: 'step 2' },
+      ]}
+      initialStep={1}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Previous'));
+
+  expect(screen.getByText('Current step: 0')).toBeInTheDocument();
+});
+
+test('Moving backward to a step without substeps resets current substep to 0', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        { label: 'step 1' },
+        {
+          label: 'step 2',
+          subSteps: [{ title: 'first' }, { title: 'second' }],
+        },
+        { label: 'step 3' },
+      ]}
+      initialStep={1}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Next'));
+  expect(screen.getByText('Current substep: 1')).toBeInTheDocument();
+
+  await user.click(screen.getByText('Go to step 0'));
+
+  expect(screen.getByText('Current step: 0')).toBeInTheDocument();
+  expect(screen.getByText('Current substep: 0')).toBeInTheDocument();
+});
+
+test('syncToURLParam navigates when setting the current step', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      syncToURLParam
+      steps={[
+        { label: 'step 1' },
+        { label: 'step 2' },
+      ]}
+    >
+      <StepperProviderLocationHarness />
+    </StepperProvider>,
+    {
+      routes: ['/create/$step'],
+      initialEntries: ['/create/0'],
+    }
+  );
+
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText('Go to step 1'));
+
+  expect(screen.getByText('Current step: 1')).toBeInTheDocument();
+  expect(screen.getByText('Current path: /create/1')).toBeInTheDocument();
+});
+
+test('isStepAtIndexDisabled returns callback result', async () => {
+  await renderWithRouter(
+    <StepperProvider
+      steps={[
+        { label: 'step 1' },
+        { label: 'step 2' },
+      ]}
+      isStepDisabled={({ stepIndex }) => stepIndex === 0}
+    >
+      <StepperProviderTestHarness />
+    </StepperProvider>
+  );
+
+  expect(screen.getByText('Step 0 disabled: true')).toBeInTheDocument();
+  expect(screen.getByText('Step 1 disabled: false')).toBeInTheDocument();
 });

--- a/src/providers/StepperProvider.tsx
+++ b/src/providers/StepperProvider.tsx
@@ -72,8 +72,7 @@ interface StepperProviderSyncedToURLParamProps extends StepperProviderProps {
   syncToURLParam: true;
 }
 
-interface StepperProviderWithoutSyncToURLParamProps
-  extends StepperProviderProps {
+interface StepperProviderWithoutSyncToURLParamProps extends StepperProviderProps {
   syncToURLParam?: undefined;
   initialStep?: number;
 }
@@ -115,16 +114,36 @@ export const StepperProvider: FC<
     throw new Error('initialStep must be a valid index of the steps array');
   }
 
+  const setSubStepForDirection = (nextStep: number) => {
+    if (nextStep === usingStep) return;
+
+    if (nextStep > usingStep) {
+      if (currentSubStep !== 0) setCurrentSubStep(0);
+      return;
+    }
+
+    const destinationStep = steps.at(nextStep);
+    if (
+      destinationStep &&
+      'subSteps' in destinationStep &&
+      destinationStep.subSteps &&
+      destinationStep.subSteps.length > 0
+    ) {
+      setCurrentSubStep(destinationStep.subSteps.length - 1);
+      return;
+    }
+
+    if (currentSubStep !== 0) setCurrentSubStep(0);
+  };
+
   const handleOnSetStep = (value: number) => {
+    setSubStepForDirection(value);
+
     if (rest.syncToURLParam) {
       navigate({ to: `${pathWithoutStep}/${value}` });
     } else {
       setCurrentStep(value);
     }
-  };
-
-  const resetCurrentSubStep = () => {
-    if (currentSubStep !== 0) setCurrentSubStep(0);
   };
 
   const goToNextStep = () => {
@@ -140,7 +159,6 @@ export const StepperProvider: FC<
     if (usingStep === steps.length - 1) return;
 
     handleOnSetStep(usingStep + 1);
-    resetCurrentSubStep();
   };
 
   const goToPreviousStep = () => {
@@ -157,12 +175,6 @@ export const StepperProvider: FC<
     if (usingStep === 0) return;
 
     handleOnSetStep(usingStep - 1);
-
-    const previousStep = steps.at(usingStep - 1);
-    if (previousStep && 'subSteps' in previousStep && previousStep.subSteps) {
-      // Set substeps to the last substep of the previous step
-      setCurrentSubStep(previousStep.subSteps.length - 1);
-    }
   };
 
   const checkIfStepIsDisabled: StepperContextType['isStepAtIndexDisabled'] =


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#715396](https://dev.azure.com/Equinor/DPP%20Upscaling%20of%20digital%20solutions/_boards/board/t/Amplify%20Component%20Library/Stories?workitem=715396)

---

- [X] Needs to be tested locally by reviewer

# Description

- Added [hideContent](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [allowJumpingAhead](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [Stepper](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Enabled forward-step clicking and updated step/icon styling to match interactive state.
- Updated Stepper stories/docs for the new props and added a jumping-ahead interaction check.
- Added tests for [hideContent](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [allowJumpingAhead](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) behavior.

