### PR TITLE
feat: allow string values for table of contents count prop

### DIFF
--- a/src/molecules/Badge/Badge.tsx
+++ b/src/molecules/Badge/Badge.tsx
@@ -7,7 +7,7 @@ import { Container } from 'src/molecules/Badge/Badge.styles';
 export type Variants = 'default' | 'light' | 'danger' | 'empty';
 
 export interface BadgeProps {
-  value: number;
+  value: number | string;
   variant?: Variants;
 }
 

--- a/src/molecules/Tabs/Tabs.types.ts
+++ b/src/molecules/Tabs/Tabs.types.ts
@@ -5,7 +5,7 @@ import { Variants } from 'src/atoms/types/variants';
 export interface Tab<T> {
   value: T;
   label: string;
-  count?: number;
+  count?: number | string;
   leadingIcon?: IconData;
   trailingIcon?: IconData;
   variant?: Extract<Variants, 'warning' | 'error'>;

--- a/src/providers/TableOfContentsProvider.tsx
+++ b/src/providers/TableOfContentsProvider.tsx
@@ -18,7 +18,7 @@ import { getValues } from 'src/providers/TableOfContentsProvider.utils';
 export interface TableOfContentsItemType {
   label: string;
   value: string;
-  count?: number;
+  count?: number | string;
   disabled?: boolean;
   children?: TableOfContentsItemType[];
 }


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#744520](https://dev.azure.com/Equinor/DPP%20Upscaling%20of%20digital%20solutions/_boards/board/t/Amplify%20Component%20Library/Stories?workitem=744520)

# Description

- Expanded count/value typing to accept both numbers and strings across related UI types.
- Updated [Badge.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code-6.localized/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so Badge value supports number | string.
- Updated [Tabs.types.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code-6.localized/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so Tab count supports number | string.
- Updated [TableOfContentsProvider.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code-6.localized/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so Table of Contents item count supports number | string.
- Scope is type-only; no runtime logic changes.

