### PR TITLE
💄 Allow passing icon props to IconButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-component-lib",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/molecules/Button/IconButton/IconButton.tsx
+++ b/src/molecules/Button/IconButton/IconButton.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react';
 
-import { Icon } from '@equinor/eds-core-react';
+import { Icon, IconProps } from '@equinor/eds-core-react';
 import { CircularProgressProps } from '@equinor/eds-core-react';
 import { IconData } from '@equinor/eds-icons';
 import type {
@@ -21,6 +21,7 @@ type Shape = 'circular' | 'square';
 
 type BaseIconButtonProps = {
   icon: IconData;
+  iconProps?: Omit<IconProps, 'data'>;
   shape?: Shape;
   children?: never;
 } & Omit<CommonButtonProps, 'children'>;
@@ -32,6 +33,7 @@ const BaseIconButton: FC<BaseIconButtonProps> = ({
   loading = false,
   shape = 'circular',
   onClick,
+  iconProps,
   ...rest
 }) => {
   const tokens = TOKEN_MAPPINGS[color][variant];
@@ -62,7 +64,7 @@ const BaseIconButton: FC<BaseIconButtonProps> = ({
           />
         </>
       ) : (
-        <Icon data={icon} />
+        <Icon data={icon} {...iconProps} />
       )}
     </IconButtonWrapper>
   );


### PR DESCRIPTION
- This pull request introduces a minor feature enhancement to the `IconButton` component, allowing consumers to pass additional props to the underlying `Icon` via a new `iconProps` prop. This increases flexibility for customizing the icon's appearance or behavior. 