### PR TITLE
💄 Prevent Tag component stretching

### DIFF
--- a/src/molecules/Tag/Tag.tsx
+++ b/src/molecules/Tag/Tag.tsx
@@ -23,6 +23,7 @@ const Container = styled.div<ContainerProps>`
   background: ${({ $color }) => TAG_COLORS[$color].background};
   min-height: 24px;
   min-width: fit-content;
+  width: fit-content;
 
   > span {
     color: ${({ $color, $textColor }) => $textColor ?? TAG_COLORS[$color].text};


### PR DESCRIPTION

<img width="535" height="141" alt="image" src="https://github.com/user-attachments/assets/e9a2ea2e-5e22-4288-8aa3-ef029e7d9c21" />

Tag component stretches unnecessarily 