### PR TITLE
fix: add min-width and center alignment to Count badge

### DIFF
--- a/src/molecules/Tabs/Tab.styles.ts
+++ b/src/molecules/Tabs/Tab.styles.ts
@@ -106,8 +106,10 @@ export const ActiveLine = styled(motion.span)`
 export const Count = styled.span`
   display: flex;
   justify-content: center;
+  align-items: center;
   padding: ${spacings.x_small} ${spacings.small};
   min-width: 24px;
+  min-height: 24px;
   background: ${colors.interactive.primary__resting.rgba};
   border-radius: ${shape.rounded.borderRadius};
   > span {

--- a/src/molecules/Tabs/Tab.styles.ts
+++ b/src/molecules/Tabs/Tab.styles.ts
@@ -105,7 +105,9 @@ export const ActiveLine = styled(motion.span)`
 
 export const Count = styled.span`
   display: flex;
+  justify-content: center;
   padding: ${spacings.x_small} ${spacings.small};
+  min-width: 24px;
   background: ${colors.interactive.primary__resting.rgba};
   border-radius: ${shape.rounded.borderRadius};
   > span {


### PR DESCRIPTION
# Azure DevOps links

## User story
- [ACL-691](https://upscaling.atlassian.net/browse/ACL-691?search_id=f9731723-6b83-478a-af3c-0c112a61195e)

---

- [ ] Needs to be tested locally by reviewer

# Description


## Test steps

1. Go to the tabs story 'With Count'
2. Change the count to '1'
3. See how the badge width changes



[ACL-691]: https://upscaling.atlassian.net/browse/ACL-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ